### PR TITLE
Use compiler built-in function __sync_synchronize() to replace x86 instruction "mfence" to support non Intel platforms.

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -2221,17 +2221,16 @@ static inline void clflush(volatile void *ptr)
         asm volatile("clflush %0" : "+m" (*(volatile char *)ptr));
 }
 
-static inline void mfence(void)
-{
-	asm volatile("mfence" : : : "memory");
-}
-
 #else
 
 #define clflush(ptr)	do { } while (0) /* No-op */
-#define mfence()	do { } while (0) /* No-op */
 
 #endif
+
+static inline void mfence(void)
+{
+	__sync_synchronize();
+}
 
 /*
  *  mwc_seed()


### PR DESCRIPTION
I am trying to add more ARM64 support to stress-ng. mfence is x86 instruction. Replace it with compiler built-in function to make it compatible with multiple platforms. Tested on Raspberry Pi 3.