### PR TITLE
Improve icache stress method and add ARM 32bit/64bit support

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -963,7 +963,7 @@ typedef enum {
 #define STRESS_HEAPSORT __STRESS_HEAPSORT
 #endif
 	STRESS_HSEARCH,
-#if defined(STRESS_X86) && defined(__GNUC__) && NEED_GNUC(4,6,0)
+#if (defined(STRESS_X86) || defined(STRESS_ARM)) && defined(__GNUC__)
 	__STRESS_ICACHE,
 #define STRESS_ICACHE __STRESS_ICACHE
 #endif


### PR DESCRIPTION
Self-modified two functions in memory and check the function
return result to verify icache flush and refill feature.

Use __clear_cache() to flush data cache and invalidate
instruction cache.

Signed-off-by: Zhiyi Sun <zhiyisun@msn.com>