### PR TITLE
Fix: Macro defination for SECCOMP_SET_MODE_FILTER

### DIFF
--- a/stress-seccomp.c
+++ b/stress-seccomp.c
@@ -24,7 +24,7 @@
  */
 #include "stress-ng.h"
 
-#if defined(HAVE_SECCOMP_H) && defined(__linux__) && defined(PR_SET_SECCOMP)
+#if defined(HAVE_SECCOMP_H) && defined(__linux__) && defined(PR_SET_SECCOMP) && defined(SECCOMP_SET_MODE_FILTER)
 
 #include <sys/prctl.h>
 #include <linux/audit.h>


### PR DESCRIPTION
stress-seccomp.c compilation failed on ppc with the below error
error: ‘SECCOMP_SET_MODE_FILTER’ undeclared (first use in this function)

this patch fixes it by adding a macro defination

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>