### PR TITLE
xattr: remove including attr/xattr.h

### DIFF
--- a/stress-xattr.c
+++ b/stress-xattr.c
@@ -26,8 +26,6 @@
 
 #if defined(__linux__) && (defined(HAVE_SYS_XATTR_H) || defined(HAVE_ATTR_XATTR_H))
 
-#include <attr/xattr.h>
-
 /*
  *  stress_xattr
  *	stress the xattr operations


### PR DESCRIPTION
xattr.h will be autodetected and included based on 1157edc18256
("xattr: autodetect for different xattr paths attr/xattr.h and
sys/xattr.h").

Signed-off-by: Jun-Ru Chang <jrjang@gmail.com>