### PR TITLE
stress-netlink-proc: fix build with kernel v3.9

### DIFF
--- a/stress-netlink-proc.c
+++ b/stress-netlink-proc.c
@@ -104,7 +104,7 @@ static int monitor(const args_t *args, const int sock)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,31)
 		case PROC_EVENT_SID:
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
 		case PROC_EVENT_COREDUMP:
 #endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,1,0)


### PR DESCRIPTION
The PROC_EVENT_COREDUMP has been introduced in kernel version 3.10.
Don't use it with 3.9 headers.

Fixes build failure:

stress-netlink-proc.c: In function 'monitor':
stress-netlink-proc.c:108:8: error: 'PROC_EVENT_COREDUMP' undeclared (first use in this function)
   case PROC_EVENT_COREDUMP:
        ^

Signed-off-by: Baruch Siach <baruch@tkos.co.il>