### PR TITLE
stress-ng: don't enable TARGET_CLONES for musl

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -1090,7 +1090,7 @@ extern void pr_fail_dbg__(const args_t *args, const char *msg);
 #endif
 
 /* GCC5.0+ target_clones attribute */
-#if defined(__GNUC__) && NEED_GNUC(5,5,0) && STRESS_X86 && \
+#if defined(__GNUC__) && defined(__GLIBC__) && NEED_GNUC(5,5,0) && STRESS_X86 && \
     !defined(__gnu_hurd__) && !defined(__FreeBSD_Kernel__)
 #define TARGET_CLONES	__attribute__((target_clones("sse","sse2","ssse3", "sse4.1", "sse4a", "avx","avx2","default")))
 #else


### PR DESCRIPTION
musl does not support gnu ifuncs

Signed-off-by: Khem Raj <raj.khem@gmail.com>