### PR TITLE
stress-ng.h: fix include on semaphore.h

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -53,7 +53,9 @@
 #include <dirent.h>
 #include <limits.h>
 #include <setjmp.h>
+#if defined(HAVE_LIB_PTHREAD) && (HAVE_SEM_POSIX)
 #include <semaphore.h>
+#endif
 #include <sched.h>
 
 #if defined(__GNUC__) && defined(__linux__)


### PR DESCRIPTION
semaphore.h is available only if HAVE_LIB_PTHREAD and
HAVE_SEM_POSIX are defined

Fixes:
 - http://autobuild.buildroot.org/results/1c95898b2833683a22bbe2ff8471fa08d94210e1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>