### PR TITLE
stress-stackmmap: needs swapcontext

### DIFF
--- a/stress-stackmmap.c
+++ b/stress-stackmmap.c
@@ -24,7 +24,7 @@
  */
 #include "stress-ng.h"
 
-#if defined(__linux__)
+#if defined(HAVE_SWAPCONTEXT)
 
 #include <ucontext.h>
 


### PR DESCRIPTION
Fixes:
 - http://autobuild.buildroot.org/results/f2d3b06afa6e31527a71c03671c8f08eb3f46c36

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>