### PR TITLE
test/test-bsd-wchar: Explicitly include stdio.h

### DIFF
--- a/test/test-bsd-wchar.c
+++ b/test/test-bsd-wchar.c
@@ -22,6 +22,7 @@
  * functionality.
  *
  */
+#include <stdio.h>
 #include <bsd/wchar.h>
 
 int main(void)


### PR DESCRIPTION
libbsd's wchar requires FILE for some it's functions, for some
reason it is not included by wchar automatically and the test fails. So
include it explicitly.

Signed-off-by: Vadim Kochan <vadim4j@gmail.com>
[Retrieved from: https://patchwork.ozlabs.org/patch/1019775]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>