### PR TITLE
stress-ng: Add stress_child_reinit

### DIFF
--- a/stress-msg.c
+++ b/stress-msg.c
@@ -154,6 +154,7 @@ again:
 		return EXIT_FAILURE;
 	} else if (pid == 0) {
 		(void)setpgid(0, g_pgrp);
+		stress_child_reinit(args);
 		stress_parent_died_alarm();
 
 		while (keep_stressing()) {

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -958,6 +958,7 @@ typedef struct {
 	pid_t pid;			/* stressor pid */
 	pid_t ppid;			/* stressor ppid */
 	size_t page_size;		/* page size */
+	uint64_t flags;			/* child reinit flags */
 } stress_args_t;
 
 typedef struct {
@@ -3573,6 +3574,9 @@ extern void stress_thrash_stop(void);
 /* Used to set options for specific stressors */
 extern void stress_adjust_pthread_max(const uint64_t max);
 extern void stress_adjust_sleep_max(const uint64_t max);
+
+extern void stress_child_reinit(const stress_args_t *args);
+
 
 /* loff_t and off64_t porting shims */
 #if defined(HAVE_LOFF_T)


### PR DESCRIPTION
Some stressors will fork() child internally, so provide a interface
for child to reinit something. And called in stress-msg.c as example.

Currently this is for SCHED_DEADLINE，fork()ed child would lose
deadline policy, mismaching the --sched deadline option.

Signed-off-by: Chunyu Hu <chuhu@redhat.com>