### PR TITLE
stress-ng: Don't track config or show in diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config
 perf-event.h
 personality.h
 stress-ng


### PR DESCRIPTION
The config file should not be tracked in git, as it is generated
dynamically from make. Also add it to the .gitignore file so it doesn't
show up in git diff

Signed-off-by: John Kacur <jkacur@redhat.com>