### PR TITLE
core-sched: init shim_sched_attr with zero

### DIFF
--- a/core-sched.c
+++ b/core-sched.c
@@ -85,6 +85,8 @@ int stress_set_deadline_sched(
 	int rc;
 	struct shim_sched_attr attr;
 
+	(void)memset(&attr, 0, sizeof(attr));
+
 	attr.size = sizeof(attr);
 	attr.sched_policy = SCHED_DEADLINE;
 	/* make sched_deadline task be able to fork*/
@@ -183,6 +185,7 @@ int stress_set_sched(
 	case SCHED_DEADLINE:
 		min = sched_get_priority_min(sched);
 		max = sched_get_priority_max(sched);
+		(void)memset(&attr, 0, sizeof(attr));
 		attr.size = sizeof(attr);
 		attr.sched_policy = SCHED_DEADLINE;
 		attr.sched_flags = SCHED_FLAG_RESET_ON_FORK;


### PR DESCRIPTION
stress-ng defined the sched_attr struct, if the version is different from
the kernel side, an '-E2BIG' would be returned to user by kernel, iff
the size of the user defined version is larger than kernel and the larger
part is not zero (man sched_setattr). So init it to avoid the issue.

Signed-off-by: Chunyu Hu <chuhu@redhat.com>