### PR TITLE
stress-ng.h: suppress kernel sysinfo.h

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -387,6 +387,8 @@
 
 #if defined(HAVE_SYS_SYSINFO_H)
 #include <sys/sysinfo.h>
+/* Suppress kernel sysinfo to avoid collision with musl */
+#define _LINUX_SYSINFO_H
 #endif
 
 #if defined(HAVE_SYS_SYSMACROS_H)


### PR DESCRIPTION
The kernel sysinfo.h (indirectly included from genetlink.h) defines
struct sysinfo. This collides with musl libc definition of the same
struct.

Fixes this build issue:

In file included from .../arm-buildroot-linux-musleabihf/sysroot/usr/include/linux/kernel.h:5,
                 from .../arm-buildroot-linux-musleabihf/sysroot/usr/include/linux/netlink.h:5,
                 from .../arm-buildroot-linux-musleabihf/sysroot/usr/include/linux/genetlink.h:6,
                 from stress-ng.h:464,
                 from stress-access.c:25:
.../arm-buildroot-linux-musleabihf/sysroot/usr/include/linux/sysinfo.h:8:8: error: redefinition of ‘struct sysinfo’
 struct sysinfo {
        ^~~~~~~
In file included from stress-ng.h:389,
                 from stress-access.c:25:
.../arm-buildroot-linux-musleabihf/sysroot/usr/include/sys/sysinfo.h:10:8: note: originally defined here
 struct sysinfo {
        ^~~~~~~

Signed-off-by: Baruch Siach <baruch@tkos.co.il>