### PR TITLE
Excercise illegal maximum priority

### DIFF
--- a/stress-nice.c
+++ b/stress-nice.c
@@ -87,7 +87,8 @@ static int stress_nice(const stress_args_t *args)
 			 *  Exercise illegal maximum priority
 			 *  to get more kernel test coverage
 			 */
-            (void)setpriority(PRIO_PROCESS, 0, max_prio + 1);
+            
+			(void)setpriority(PRIO_PROCESS, 0, max_prio + 1);
 
 			switch (which) {
 #if defined(HAVE_SETPRIORITY)

--- a/stress-nice.c
+++ b/stress-nice.c
@@ -83,6 +83,12 @@ static int stress_nice(const stress_args_t *args)
 			stress_parent_died_alarm();
 			(void)sched_settings_apply(true);
 
+			/*
+			 *  Exercise illegal maximum priority
+			 *  to get more kernel test coverage
+			 */
+            (void)setpriority(PRIO_PROCESS, 0, max_prio + 1);
+
 			switch (which) {
 #if defined(HAVE_SETPRIORITY)
 			case 1:


### PR DESCRIPTION
Modified stress-nice.c to exercise an illegal maximum priority to get more kernel test coverage