### PR TITLE
Update stress-sysinval.c

### DIFF
--- a/stress-sysinval.c
+++ b/stress-sysinval.c
@@ -642,8 +642,8 @@ static const stress_syscall_arg_t stress_syscall_args[] = {
 	{ SYS(getresuid), 3, { ARG_PTR_WR, ARG_PTR_WR, ARG_PTR_WR, 0, 0, 0 } },
 #endif
 #if DEFSYS(getresuid32)
-	{ SYS(getresuid), 3, { ARG_PTR, ARG_PTR, ARG_PTR, 0, 0, 0 } },
-	{ SYS(getresuid), 3, { ARG_PTR_WR, ARG_PTR_WR, ARG_PTR_WR, 0, 0, 0 } },
+	{ SYS(getresuid32), 3, { ARG_PTR, ARG_PTR, ARG_PTR, 0, 0, 0 } },
+	{ SYS(getresuid32), 3, { ARG_PTR_WR, ARG_PTR_WR, ARG_PTR_WR, 0, 0, 0 } },
 #endif
 #if DEFSYS(getrlimit)
 	{ SYS(getrlimit), 2, { ARG_RND, ARG_PTR, 0, 0, 0, 0 } },


### PR DESCRIPTION
Fixing a build error for x86 architectures.

Fix issues [#75 ]