### PR TITLE
Fix some requirement names

### DIFF
--- a/README
+++ b/README
@@ -54,9 +54,9 @@ RHEL, Fedora, Centos:
   * libcap-devel
   * libgcrypt-devel
   * Judy-devel
-  * keyutils-libs
+  * keyutils-libs-devel
   * lksctp-tools-devel
-  * libatomic1
+  * libatomic
   * zlib-devel
 
 SUSE:


### PR DESCRIPTION
A couple of the requirement names are not quite correct in the
doc for RHEL/CentOS/Fedora and this commit fixes them.