### PR TITLE
Fix off-by-ones strncmp in stress-dev.c

### DIFF
--- a/stress-dev.c
+++ b/stress-dev.c
@@ -2633,8 +2633,8 @@ static inline void stress_dev_rw(
     defined(TCGETS) && \
     defined(HAVE_TERMIOS)
 		if (S_ISCHR(buf.st_mode) &&
-		    strncmp("/dev/vsock", path, 9) &&
-		    strncmp("/dev/dri", path, 7) &&
+		    strncmp("/dev/vsock", path, 10) &&
+		    strncmp("/dev/dri", path, 8) &&
 		    (ioctl(fd, TCGETS, &tios) == 0))
 			stress_dev_tty(args->name, fd, path);
 #endif


### PR DESCRIPTION
This was found with a "cstrnfinder" research and I haven't tested this change (more info https://twitter.com/disconnect3d_pl/status/1339757359896408065). Close this PR if this change is incorrect.