### PR TITLE
Fix read of TYPE_ID_STR value from jobfile

### DIFF
--- a/core-helper.c
+++ b/core-helper.c
@@ -671,7 +671,9 @@ uint64_t stress_uint64_zero(void)
  */
 int stress_set_temp_path(const char *path)
 {
-	stress_temp_path = path;
+	stress_temp_path = stress_const_optdup(path);
+	if (!stress_temp_path)
+		return -1;
 
 	if (access(path, R_OK | W_OK) < 0) {
 		(void)fprintf(stderr, "temp-path '%s' must be readable "

--- a/core-setting.c
+++ b/core-setting.c
@@ -146,7 +146,11 @@ static int stress_set_setting_generic(
 		DBG("%s: OFF_T: %s -> %lu\n", __func__, name, (unsigned long)setting->u.off);
 		break;
 	case TYPE_ID_STR:
-		setting->u.str = (const char *)value;
+		setting->u.str = stress_const_optdup(value);
+		if (!setting->u.str) {
+			free(setting);
+			goto err;
+		}
 		DBG("%s: STR: %s -> %s\n", __func__, name, setting->u.str);
 		break;
 	case TYPE_ID_BOOL:


### PR DESCRIPTION
When defining log-file, yaml, or temp-path with the jobfile, the value of it may be changed as the parsing of the jobfile proceeds. The reason is that these values are still pointing to the _buf_ used by fgets in _core-job.c_.

Signed-off-by: Jianshen Liu \<jliu120@ucsc.edu\>