### PR TITLE
stress-ng.h: fix build-breaking HAVE_USTAT typo

### DIFF
--- a/core-shim.c
+++ b/core-shim.c
@@ -1390,7 +1390,8 @@ int sys_clone3(struct shim_clone_args *cl_args, size_t size)
 
 int shim_ustat(dev_t dev, struct shim_ustat *ubuf)
 {
-#if defined(HAVE_USTAT)
+#if defined(HAVE_USTAT) && \
+     defined(HAVE_USTAT_H)
 	return ustat(dev, (void *)ubuf);
 #elif defined(__NR_ustat)
 	return syscall(__NR_ustat, dev, ubuf);

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -219,7 +219,7 @@
 #include <ucontext.h>
 #endif
 
-#if defined(HAVE_USTAT)
+#if defined(HAVE_USTAT_H)
 #include <ustat.h>
 #endif
 


### PR DESCRIPTION
This minor typo fails builds on newer glibc because ustat.h does
not exist anymore.