### PR TITLE
stress-cpu.c update proc state to RUN before the main loop

### DIFF
--- a/stress-cpu.c
+++ b/stress-cpu.c
@@ -2828,18 +2828,7 @@ static int HOT OPTIMIZE3 stress_cpu(const stress_args_t *args)
 	func = cpu_method->func;
 
 	pr_dbg("%s using method '%s'\n", args->name, cpu_method->name);
-
-	/*
-	 * Normal use case, 100% load, simple spinning on CPU
-	 */
-	if (cpu_load == 100) {
-		do {
-			(void)func(args->name);
-			inc_counter(args);
-		} while (keep_stressing(args));
-		return EXIT_SUCCESS;
-	}
-
+	
 	/*
 	 * It is unlikely, but somebody may request to do a zero
 	 * load stress test(!)
@@ -2851,6 +2840,17 @@ static int HOT OPTIMIZE3 stress_cpu(const stress_args_t *args)
 
 	stress_set_proc_state(args->name, STRESS_STATE_RUN);
 
+	/*
+	 * Normal use case, 100% load, simple spinning on CPU
+	 */
+	if (cpu_load == 100) {
+		do {
+			(void)func(args->name);
+			inc_counter(args);
+		} while (keep_stressing(args));
+		return EXIT_SUCCESS;
+	}
+	
 	/*
 	 * More complex percentage CPU utilisation.  This is
 	 * not intended to be 100% accurate timing, it is good


### PR DESCRIPTION
Transition from INIT to RUN before the main loop.

Otherwise it will be stuck in INIT (and showing `stress-ng-cpu [init]` as process name)
for the entire run.

Signed-off-by: Witold Baryluk <witold.baryluk@gmail.com>