### PR TITLE
Fix syslog logging when shim_strlcat re-implementation is used

### DIFF
--- a/core-shim.c
+++ b/core-shim.c
@@ -1048,7 +1048,7 @@ size_t shim_strlcat(char *dst, const char *src, size_t len)
 #else
 	register char *d = dst;
 	register const char *s = src;
-	register size_t n = len, tmplen;
+	register size_t n = len++, tmplen;
 
 	while (n-- && *d != '\0') {
 		d++;


### PR DESCRIPTION
Logging how stress-ng is invoked leaves cut messages in syslog
if the re-implemented shim_strlcat() is used:

  "... invoked with './stress-n' by user 1000"

This seems due to a temporary variable which is too small, and
this patch proposes a fix.