### PR TITLE
Fix duration output missing when sequential mode

### DIFF
--- a/stress-ng.c
+++ b/stress-ng.c
@@ -3200,7 +3200,11 @@ static void stress_set_default_timeout(const uint64_t timeout)
 		pr_inf("defaulting to a %" PRIu64 " second%s run per stressor\n",
 			g_opt_timeout,
 			stress_duration_to_str((double)g_opt_timeout));
-	}
+	}else {
+		pr_inf("setting to a %" PRIu64 " second%s run per stressor\n",
+			g_opt_timeout,
+			stress_duration_to_str((double)g_opt_timeout));
+    }
 }
 
 /*


### PR DESCRIPTION
When I use the '--seq' option, stress-ng will output the following line:
`
stress-ng: info:  [25541] defaulting to a 60 second run per stressor
`

it means the test duration per stressor is the 60s; looks well;

But when I append '-t 5m' options, this line is disappeared, with nothing else;

This patch will add a branch on control flow to tell the user about the duration for each stressor,
the screen log will become more meaningful for debugger;
