### PR TITLE
stress-ng: Fix random stressor assignment

### DIFF
--- a/stress-ng.c
+++ b/stress-ng.c
@@ -2916,18 +2916,14 @@ static inline void stress_set_random_stressors(void)
 
 		/* create n randomly chosen stressors */
 		while (n > 0) {
-			uint32_t rnd32 = stress_mwc32();
-			int32_t rnd = (int32_t)rnd32 % ((opt_random >> 5) + 2);
 			const uint32_t i = stress_mwc32() % n_procs;
 			stress_stressor_t *ss = stress_get_nth_stressor(i);
 
 			if (!ss)
 				continue;
 
-			if (rnd > n)
-				rnd = n;
-			ss->num_instances += rnd;
-			n -= rnd;
+			ss->num_instances++;
+			n--;
 		}
 	}
 }


### PR DESCRIPTION
The -r option allows picking N random stressors. The initialization
routine involved selecting a random stressor, and then chosing how many
instances to chose for that stressor.

However, the computation used a mix of signed and unsigned integer logic that
underflowed the num_instances field for the selected stressors, which lead to
a "cannot allocate pid list" error during the memory allocation for
the pid list in stress_alloc_proc_resources().

Simply fixing the integer logic isn't enough since it often leads to
situations where 0 instances of a given stressor would be selected,
making the while loop in stress_set_random_stressors() unpredictable in
its execution time.

This commit solves the issue by always allocating 1 of the randomly selected
stressors. There's nothing preventing multiple instances of any stressor
from being picked more than once, so the original intended behaviour is
kept.

Signed-off-by: Maxime Chevallier <maxime.chevallier@bootlin.com>