### PR TITLE
fix: opt_set_funcs undeclared

### DIFF
--- a/stress-nop.c
+++ b/stress-nop.c
@@ -178,7 +178,6 @@ stressor_info_t stress_nop_info = {
 stressor_info_t stress_nop_info = {
 	.stressor = stress_not_implemented,
 	.class = CLASS_CPU,
-	.opt_set_funcs,
 	.help = help
 };
 #endif


### PR DESCRIPTION
Hi,

I had been ported the project to arm64.  I referenced code base and to remove opt_set_funcs of  stress_nop_info.
It's perfect to build via cross-compiler and run well on arm64.


