### PR TITLE
core-helper: Quote the system-info.version value in YAML metrics

### DIFF
--- a/core-helper.c
+++ b/core-helper.c
@@ -1115,7 +1115,7 @@ void pr_yaml_runinfo(FILE *yaml)
 		pr_yaml(yaml, "      sysname: %s\n", uts.sysname);
 		pr_yaml(yaml, "      nodename: %s\n", uts.nodename);
 		pr_yaml(yaml, "      release: %s\n", uts.release);
-		pr_yaml(yaml, "      version: %s\n", uts.version);
+		pr_yaml(yaml, "      version: '%s'\n", uts.version);
 		pr_yaml(yaml, "      machine: %s\n", uts.machine);
 	}
 #endif


### PR DESCRIPTION
The value of `system-info.version` typically begins with a pound sign. When used as a bare value, any YAML parser will interpret the value as `null` and followed by a comment.

This change has the value quoted in the YAML, so the pound sign is actually considered part of the value.