### PR TITLE
Makefile: do not write the timestamp into compressed manpage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,7 @@ git-commit-id.h:
 $(OBJS): stress-ng.h Makefile
 
 stress-ng.1.gz: stress-ng.1
-	$(V)gzip -c $< > $@
+	$(V)gzip -n -c $< > $@
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
This helps reproducibility.
