### PR TITLE
stress-ng: Fix potential overrun in msgsnd

### DIFF
--- a/stress-msg.c
+++ b/stress-msg.c
@@ -163,7 +163,7 @@ static void stress_msgsnd(const int msgq_id)
 	/* Invalid msgq_id */
 	msg.mtype = 1;
 	msg.value = 0;
-	ret = msgsnd(-1, &msg, sizeof(msg), 0);
+	ret = msgsnd(-1, &msg, sizeof(msg.value), 0);
 	(void)ret;
 
 	/* Zero msg length + 0 msg.type */
@@ -173,7 +173,7 @@ static void stress_msgsnd(const int msgq_id)
 
 	/* Illegal flags, may or may not succeed */
 	msg.mtype = 1;
-	ret = msgsnd(msgq_id, &msg, sizeof(msg), ~0);
+	ret = msgsnd(msgq_id, &msg, sizeof(msg.value), ~0);
 	(void)ret;
 }
 


### PR DESCRIPTION
The msgsz argument to msgsnd should be the maximum size of mtext member
or in the case of the stress_msg_t, the value member.

Making msgsz too big could potentially cause an overrun since it will
access this memory at the offset where the mtext member begins.

Signed-off-by: John Kacur <jkacur@redhat.com>