### PR TITLE
Define nop for each architecture and add the KVX arch

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -1387,7 +1387,7 @@ static inline void shim_builtin_prefetch(const void *addr, ...)
 
 /* do nothing */
 #if defined(HAVE_ASM_NOP)
-#define FORCE_DO_NOTHING() __asm__ __volatile__("nop;")
+#define FORCE_DO_NOTHING() __asm__ __volatile__(ARCH_ASM_NOP)
 #elif defined(HAVE_ASM_NOTHING)
 #define FORCE_DO_NOTHING() __asm__ __volatile__("")
 #else
@@ -1851,6 +1851,7 @@ extern void pr_dbg_lock(bool *locked, const char *fmt, ...)  FORMAT(printf, 2, 3
 #if defined(__x86_64__) || defined(__x86_64) || \
     defined(__i386__)   || defined(__i386)
 #define STRESS_ARCH_X86		(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* Arch specific, ARM */
@@ -1862,22 +1863,26 @@ extern void pr_dbg_lock(bool *locked, const char *fmt, ...)  FORMAT(printf, 2, 3
     defined(__ARM_ARCH_7M__)  || defined(__ARM_ARCH_7EM__) || \
     defined(__ARM_ARCH_8A__)  || defined(__aarch64__)
 #define STRESS_ARCH_ARM		(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* Arch specific RISC-V */
 #if defined(__riscv) || \
     defined(__riscv__)
 #define STRESS_ARCH_RISCV	(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* Arch specific, IBM S390 */
 #if defined(__s390__)
 #define STRESS_ARCH_S390	(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* Arch specific PPC64 */
 #if defined(__PPC64__)
 #define STRESS_ARCH_PPC64	(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* Arch specific M68K */
@@ -1886,6 +1891,7 @@ extern void pr_dbg_lock(bool *locked, const char *fmt, ...)  FORMAT(printf, 2, 3
     defined(__mc68010__) ||	\
     defined(__mc68020__)
 #define STRESS_ARCH_M68K	(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* Arch specific SPARC */
@@ -1893,11 +1899,13 @@ extern void pr_dbg_lock(bool *locked, const char *fmt, ...)  FORMAT(printf, 2, 3
     defined(__sparc__) ||	\
     defined(__sparc_v9__)
 #define STRESS_ARCH_SPARC	(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* Arch specific SH4 */
 #if defined(__SH4__)
 #define STRESS_ARCH_SH4		(1)
+#define ARCH_ASM_NOP "nop;\n"
 #endif
 
 /* GCC5.0+ target_clones attribute, x86 */

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -1908,6 +1908,14 @@ extern void pr_dbg_lock(bool *locked, const char *fmt, ...)  FORMAT(printf, 2, 3
 #define ARCH_ASM_NOP "nop;\n"
 #endif
 
+/* Arch specific Kalray VLIW core */
+#if defined(__KVX__) || \
+    defined(__kvx__)
+#define STRESS_ARCH_KVX	(1)
+
+#define ARCH_ASM_NOP "nop;;\n"
+#endif
+
 /* GCC5.0+ target_clones attribute, x86 */
 #if defined(STRESS_ARCH_X86) &&	\
     defined(HAVE_TARGET_CLONES)

--- a/test/test-asm-nop.c
+++ b/test/test-asm-nop.c
@@ -1,3 +1,4 @@
+#include "stress-ng.h"
 /*
  * Copyright (C) 2017-2021 Canonical, Ltd.
  *
@@ -23,10 +24,13 @@
  *
  */
 
+#if defined(ARCH_ASM_NOP)
 int main(void)
 {
-	__asm__ __volatile__("nop;");
+	__asm__ __volatile__(ARCH_ASM_NOP);
 
 	return 0;
 }
-
+#else
+#error no nop instruction defined
+#endif


### PR DESCRIPTION
I've stumbled on a compilation issue when trying to rebase on a newer version of buildroot 2021.08
which I believed updated stress-ng to V0.13.07.
The `test-asm-nop.c` was compiling fine but `stress-nop.c` was not compiling.

By looking further down the rabbit hole I've tried to come with a solution to the issue I was facing.
At first I've tried to see if it wasn't a compiler bug from our side... but it does not. The cold reality I was facing is the fact that plain asm cannot be expected to be universally shared, and architectural quirks will always ends up biting you...

This might not be the best solution to this problem, but I am trying nonetheless to fix this since I am most likely to be the only one face such silly issues (`;;` is required to end an "instruction").
I don't expect this fix to be the final solution but I hope it at least raise the issue.
