### PR TITLE
Fixes for Kalray's KVX asm

### DIFF
--- a/stress-nop.c
+++ b/stress-nop.c
@@ -68,7 +68,7 @@ static inline void stress_op_nop(void)
 	 * Extra ;; required for KVX to indicate end of
 	 * a VLIW instruction bundle
 	 */
-	__asm__ __volatile__("nop;;\n");
+	__asm__ __volatile__("nop\n;;\n");
 #else
 	__asm__ __volatile__("nop;\n");
 #endif

--- a/stress-rseq.c
+++ b/stress-rseq.c
@@ -47,13 +47,25 @@ static const stress_help_t help[] = {
 #define OPTIMIZE0       __attribute__((optimize("-O0")))
 #endif
 
-#define NOPS()		\
-asm volatile(		\
-	"nop\n"		\
-	"nop\n"		\
-	"nop\n"		\
-	"nop\n"		\
-);
+static inline void stress_op_nop(void)
+{
+#if defined(STRESS_ARCH_KVX)
+	/*
+	 * Extra ;; required for KVX to indicate end of
+	 * a VLIW instruction bundle
+	 */
+	__asm__ __volatile__("nop\n;;\n");
+#else
+	__asm__ __volatile__("nop;\n");
+#endif
+}
+
+#define NOPS()	do {		\
+	stress_op_nop();	\
+	stress_op_nop();	\
+	stress_op_nop();	\
+	stress_op_nop();	\
+} while (0);
 
 typedef struct {
 	uint64_t crit_count;		/* critical path entry count */


### PR DESCRIPTION
Apparently the Kalray's asm end of bundle marker must be on it's own line, otherwise (if placed after an instruction) the `;;` marker is a comment...
I am sorry that I didn't got this right the first time.
Here is a fix for stress-nop plus the same thing done for stress-rseq.