### PR TITLE
stress-sem: fix macro definition

### DIFF
--- a/stress-sem.c
+++ b/stress-sem.c
@@ -45,7 +45,7 @@ static const stress_opt_set_func_t opt_set_funcs[] = {
 	{ 0,			NULL }
 };
 
-#if defined(HAVE_SEM_POSIX_H) && \
+#if defined(HAVE_SEMAPHORE_H) && \
     defined(HAVE_LIB_PTHREAD) && \
     defined(HAVE_SEM_POSIX)
 


### PR DESCRIPTION
Fixes the below stress-sem issue: 

```
stress-ng-sem: this stressor is not implemented on this system: ppc64le Linux 5.17.0-rc1+ gcc 8.4
```

Seems like it is recently introduced here:

https://github.com/ColinIanKing/stress-ng/commit/7fdd4c9d2791bb9d0dd5ab1f6fb51bbf3d2aa839#diff-5ba7b9baa4cbef686c61e31b162abc3fb3993161eb3f931dbf880bcc888d37bbL49

Thanks.