### PR TITLE
Makefile: quote CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,7 +432,7 @@ stress-ng: $(OBJS)
 	$(V)sync
 
 config.h:
-	$(MAKE) CC=$(CC) STATIC=$(STATIC) -f Makefile.config
+	$(MAKE) CC="$(CC)" STATIC=$(STATIC) -f Makefile.config
 
 .PHONY:
 makeconfig: config.h

--- a/Makefile.config
+++ b/Makefile.config
@@ -69,7 +69,7 @@ else
 endif
 
 
-MAKE_OPTS=CC=$(CC) -f Makefile.config --no-print-directory
+MAKE_OPTS=CC="$(CC)" -f Makefile.config --no-print-directory
 
 comma = ,
 


### PR DESCRIPTION
It can contain command line options, and therefore spaces, and so
needs to be quoted.

Signed-off-by: Alexander Kanavin <alex@linutronix.de>