### PR TITLE
Enable getrandom test on FreeBSD

### DIFF
--- a/stress-getrandom.c
+++ b/stress-getrandom.c
@@ -31,6 +31,7 @@ static const stress_help_t help[] = {
 
 #if defined(__OpenBSD__) || 	\
     defined(__APPLE__) || 	\
+    defined(__FreeBSD__) ||	\
     (defined(__linux__) && defined(__NR_getrandom))
 
 #if defined(__OpenBSD__) ||	\


### PR DESCRIPTION
I think modern versions of FreeBSD (>=12) can run `--getrandom` and `--getrandom-ops` tests. Please, correct me if I'm wrong or further changes need to be done.