### PR TITLE
[Fix] Clear Hugepages bits from mmap_flags

### DIFF
--- a/stress-mmap.c
+++ b/stress-mmap.c
@@ -90,17 +90,6 @@ static const int mmap_std_flags[] = {
 
 /* Misc randomly chosen mmap flags */
 static const int mmap_flags[] = {
-#if defined(MAP_HUGE_2MB) &&	\
-    defined(MAP_HUGETLB)
-	MAP_HUGE_2MB | MAP_HUGETLB,
-#endif
-#if defined(MAP_HUGE_1GB) &&	\
-    defined(MAP_HUGETLB)
-	MAP_HUGE_1GB | MAP_HUGETLB,
-#endif
-#if defined(MAP_HUGETLB)
-	MAP_HUGETLB,
-#endif
 #if defined(MAP_NONBLOCK)
 	MAP_NONBLOCK,
 #endif


### PR DESCRIPTION
Regular mmap should not set hugepage bits for mmap_flags.
Hugepages should be addressed in mmaphuge instead.

This patch removes hugepage bits from mmap_flags to fix memory
issues with regular mmap stressor when Hugepages are allocated
but not available to containers or pods that don't have access
to the hugepages mount points.

Closes #196