### PR TITLE
docs: Fix a few typos

### DIFF
--- a/stress-apparmor.c
+++ b/stress-apparmor.c
@@ -438,7 +438,7 @@ static inline void apparmor_corrupt_set_seq(
 
 /*
  *  apparmor_corrupt_flip_byte_random()
- *	ramndomly flip entire bytes
+ *	randomly flip entire bytes
  */
 static inline void apparmor_corrupt_flip_byte_random(
 	char *copy, const size_t len)

--- a/stress-opcode.c
+++ b/stress-opcode.c
@@ -402,7 +402,7 @@ again:
 			 * Originally we unmapped these, but this is
 			 * another system call required that may go
 			 * wrong because libc or the stack has been
-			 * trashsed, so just skip it.
+			 * trashed, so just skip it.
 			 *
 			(void)munmap(opcodes, page_size * PAGES);
 			 */


### PR DESCRIPTION
There are small typos in:
- stress-apparmor.c
- stress-opcode.c

Fixes:
- Should read `trashed` rather than `trashsed`.
- Should read `randomly` rather than `ramndomly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md