### PR TITLE
Avoid redefining _FORTIFY_SOURCE

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -35,7 +35,8 @@
 #define _LARGEFILE64_SOURCE
 #endif
 #if !defined(__PCC__) && 	\
-    !defined(__TINYC__)
+    !defined(__TINYC__) &&	\
+    !defined(_FORTIFY_SOURCE)
 #define _FORTIFY_SOURCE 2
 #endif
 


### PR DESCRIPTION
Distributions add build flags through the environment to build packages
with fortification, which may result in redefinition of _FORTIFY_SOURCE.
This is particularly problematic in cases where the distribution may
look to build with a higher level of fortification (_FORTIFY_SOURCE=3),
in which case stress-ng misses out, overriding it with
_FORTIFY_SOURCE=2.

Fix this by defining _FORTIFY_SOURCE only if it hasn't already been
defined.