### PR TITLE
stress-exec: Add option to not call execveat().

### DIFF
--- a/stress-ng.c
+++ b/stress-ng.c
@@ -384,6 +384,7 @@ static const struct option long_options[] = {
 	{ "exec",		1,	0,	OPT_exec },
 	{ "exec-ops",		1,	0,	OPT_exec_ops },
 	{ "exec-max",		1,	0,	OPT_exec_max },
+	{ "exec-no-execveat",	0,	0,	OPT_exec_no_execveat },
 	{ "exit-group",		1,	0,	OPT_exit_group },
 	{ "exit-group-ops",	1,	0,	OPT_exit_group_ops },
 	{ "fallocate",		1,	0,	OPT_fallocate },

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -1607,6 +1607,7 @@ typedef enum {
 	OPT_exec,
 	OPT_exec_ops,
 	OPT_exec_max,
+	OPT_exec_no_execveat,
 
 	OPT_exit_group,
 	OPT_exit_group_ops,


### PR DESCRIPTION
Hi.

First, I hope you are fine and the same for your relatives.

In this patch, I added an option to make the exec stressor uses only `execve()`, thus not calling `execveat()`:

```bash
$ make clean
$ make -j$(nproc)
...
LD stress-ng
$ strace -f ./stress-ng --exec 1 --exec-no-execveat --timeout 1s &> /tmp/without
$ strace -f ./stress-ng --exec 1 --timeout 1s &> /tmp/with
$ grep -c execveat /tmp/with /tmp/without
/tmp/with:216
/tmp/without:1
$ grep execveat /tmp/without
execve("./stress-ng", ["./stress-ng", "--exec", "1", "--exec-no-execveat", "--timeout", "1s"], 0x7ffcca406360 /* 58 vars */) = 0
```

Indeed, I wanted to test eBPF tool which traces `execve()` syscall and I was surprised by seeing there were less eBPF events than `stress-ng` bogo ops.
I just checked `stress-ng` code and realized it could use `execveat()` for the exec stressor.
So, rather than crafting myself a tool to only generate `execve()` events, I think this can be useful for other people to restrict this stressor to use `execve()`.

If you see any way to improve this contribution, feel free to share.

Best regards and thank you in advance.