### PR TITLE
stress-exec: add fork method option to select the fork call to use

### DIFF
--- a/stress-ng.1
+++ b/stress-ng.1
@@ -1681,6 +1681,10 @@ select the exec system call to use; all will perform a random choice between
 execve(2) and execveat(2), execve will use execve(2) and execveat will use
 execveat(2) if it is available.
 .TP
+.B \-\-exec\-fork\-method [ fork | clone ]
+select the fork systemm call to use; fork will use fork(2) and clone will use
+clone(2).
+.TP
 .B \-\-exit\-group N
 start N workers that create 16 pthreads and terminate the pthreads and
 the controlling child process using exit_group(2). (Linux only stressor).

--- a/stress-ng.c
+++ b/stress-ng.c
@@ -385,6 +385,7 @@ static const struct option long_options[] = {
 	{ "exec-ops",		1,	0,	OPT_exec_ops },
 	{ "exec-max",		1,	0,	OPT_exec_max },
 	{ "exec-method",	1,	0,	OPT_exec_method },
+	{ "exec-fork-method",	1,	0,	OPT_exec_fork_method },
 	{ "exit-group",		1,	0,	OPT_exit_group },
 	{ "exit-group-ops",	1,	0,	OPT_exit_group_ops },
 	{ "fallocate",		1,	0,	OPT_fallocate },

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -1610,6 +1610,7 @@ typedef enum {
 	OPT_exec_ops,
 	OPT_exec_max,
 	OPT_exec_method,
+	OPT_exec_fork_method,
 
 	OPT_exit_group,
 	OPT_exit_group_ops,


### PR DESCRIPTION
Hi.


In this patch, I added a way to use `vfork()` instead of `fork()`.
Using `vfork()` will indeed less stress the machine as the parent page table will not be copied to the child
It nonetheless permits a better throughtput of `exec` calls:

```
$ ./stress-ng --exec 1 --exec-method execve --exec-fork-method fork --timeout 1s --metrics-brief
stress-ng: info:  [211952] setting to a 1 second run per stressor
stress-ng: info:  [211952] dispatching hogs: 1 exec
stress-ng: info:  [211952] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s
stress-ng: info:  [211952]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: info:  [211952] exec                906      1.00      0.00      0.00       905.92           0.00
stress-ng: info:  [211952] successful run completed in 1.00
$ ./stress-ng --exec 1 --exec-method execve --exec-fork-method vfork --timeout 1s --metrics-brief
stress-ng: info:  [213374] setting to a 1 second run per stressor
stress-ng: info:  [213374] dispatching hogs: 1 exec
stress-ng: info:  [213374] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s
stress-ng: info:  [213374]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: info:  [213374] exec               9891      1.00      0.00      0.00      9891.35           0.00
stress-ng: info:  [213374] successful run completed in 1.01s
```

Sadly, I had to set some variables as `volatile` as parent and child share the same memory before the child calls `exec()`.
Also, `vfork()` POSIX status is not perfect, as I do not know what is `stress-ng` goal regarding POSIX:

> CONFORMING TO
       4.3BSD; POSIX.1-2001 (but marked OBSOLETE).  POSIX.1-2008 removes the specification of vfork().

If you see any way to improve this contribution, feel free to share!


Best regards and thank you in advance.
 
