### PR TITLE
stress-exec: add an option to not call pthread

### DIFF
--- a/stress-ng.1
+++ b/stress-ng.1
@@ -1690,6 +1690,9 @@ execveat(2) if it is available.
 select the fork systemm call to use; fork will use fork(2) and clone will use
 clone(2).
 .TP
+.B \-\-exec\-no\-pthread
+do not use pthread_create(3).
+.TP
 .B \-\-exit\-group N
 start N workers that create 16 pthreads and terminate the pthreads and
 the controlling child process using exit_group(2). (Linux only stressor).

--- a/stress-ng.c
+++ b/stress-ng.c
@@ -393,6 +393,7 @@ static const struct option long_options[] = {
 	{ "exec-max",		1,	0,	OPT_exec_max },
 	{ "exec-method",	1,	0,	OPT_exec_method },
 	{ "exec-fork-method",	1,	0,	OPT_exec_fork_method },
+	{ "exec-no-pthread",	0,	0,	OPT_exec_no_pthread },
 	{ "exit-group",		1,	0,	OPT_exit_group },
 	{ "exit-group-ops",	1,	0,	OPT_exit_group_ops },
 	{ "fallocate",		1,	0,	OPT_fallocate },

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -1179,6 +1179,7 @@ typedef enum {
 	OPT_exec_max,
 	OPT_exec_method,
 	OPT_exec_fork_method,
+	OPT_exec_no_pthread,
 
 	OPT_exit_group,
 	OPT_exit_group_ops,


### PR DESCRIPTION
Hi.


In this PR, I added an option to avoid `stress-ng` to use `pthread_create()`.
Indeed, in the following code, if the pthread is successful, the function will return and no `exec(2)` will be called:
https://github.com/ColinIanKing/stress-ng/blob/c10e5c3f9f5560a085279f4c4b399c2f34cb897d/stress-exec.c#L393-L407
But the number of `exec_calls` will still be incremented.
This was reported by @mauriciovasquezbernal.

This was a problem for me, as I am counting the number of `exec(2)` syscalls with an eBPF tool.
Now, with this modification the number are the same:

```bash
$ sudo ./execsnoop > tmp/exec.out &
$ $ ./stress-ng --exec 1 --exec-method execve --exec-fork-method clone --exec-no-pthread --timeout 1s --metrics-brief
stress-ng: info:  [55845] setting to a 1 second run per stressor
stress-ng: info:  [55845] dispatching hogs: 1 exec
stress-ng: info:  [55845] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s
stress-ng: info:  [55845]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: info:  [55845] exec               8808      1.05      6.00      6.00      8361.53      125828.57
stress-ng: info:  [55845] successful run completed in 1.05s
$ fg
^C
$ grep 'stress-ng' /tmp/exec.out | wc -l
8809
```

(There is one exec more reported by `execsnoop` because it reports the `exec` to create the application made by the shell)

I am maybe modifying too much `stress-ng` to suit my cases which does not really correspond to stressing a system, so I would totally understand you do not like this modifcation.
In any case, if you see any way to improve it, feel free to share.


Best regards and thank you.