### PR TITLE
stress-ng: stress-mmapmany: Remove deadcode

### DIFF
--- a/stress-mmapmany.c
+++ b/stress-mmapmany.c
@@ -39,11 +39,6 @@ static int stress_mmapmany_child(const stress_args_t *args, void *context)
 
 	(void)context;
 
-	if (max < 1) {
-		pr_fail("%s: sysconf(_SC_MAPPED_FILES) is too low, max = %ld\n",
-			args->name, max);
-		return EXIT_NO_RESOURCE;
-	}
 	mappings = calloc((size_t)max, sizeof(*mappings));
 	if (!mappings) {
 		pr_fail("%s: malloc failed, out of memory\n", args->name);


### PR DESCRIPTION
max can never be less than 1 because after we assign
long max = sysconf(_SC_MAPPED_FILES);
we make max the maximum of that or MMAP_MAX
max = STRESS_MAXIMUM(max, MMAP_MAX);

Furthermore the test isn't that meaningful, beause with a limit
if sysconf returned -1 that just means that the limit in indeterminable.

The option to removing the deadcode would be to test
if errno is also EINVAL after sysconf which would indicate that the
_SC_MAPPED_FILES

Signed-off-by: John Kacur <jkacur@redhat.com>