### PR TITLE
stress-ng: sparsematrix: Fix null check

### DIFF
--- a/stress-sparsematrix.c
+++ b/stress-sparsematrix.c
@@ -217,7 +217,7 @@ static void *hash_create(const uint64_t n, const uint32_t x, const uint32_t y)
 		return NULL;
 
 	table->table = (sparse_hash_node_t **)calloc((size_t)n_prime, sizeof(sparse_hash_node_t *));
-	if (!table) {
+	if (!table->table) {
 		free(table);
 		return NULL;
 	}
@@ -356,7 +356,7 @@ static void *qhash_create(const uint64_t n, const uint32_t x, const uint32_t y)
 		return NULL;
 
 	table->table = (sparse_qhash_node_t **)calloc((size_t)n_prime, sizeof(sparse_qhash_node_t *));
-	if (!table) {
+	if (!table->table) {
 		free(table);
 		return NULL;
 	}


### PR DESCRIPTION
table already exists, or we would have returned NULL

The value we want to check is table->table, if that is NULL we can free
table and return NULL

Fix in functions hash_create and qhash_create

Signed-off-by: John Kacur <jkacur@redhat.com>