### PR TITLE
stress-regs: ppc64le: Fix compilation error for REGS_CHECK macro.

### DIFF
--- a/stress-regs.c
+++ b/stress-regs.c
@@ -617,7 +617,7 @@ do {			\
 	SHUFFLE_REGS16();
 
 	stash64 = r14;
-	REGS_CHECK(args, "r14", stash64);
+	REGS_CHECK(args, "r14", (v >> 1), stash64);
 
 	stash64 = r14 + r15 + r16 + r17 +
 		r18 + r19 + r20 + r21 +


### PR DESCRIPTION
Hi.


I wanted to use the last version of `stress-ng` docker image but I realized the last version does not contain features added this week.
I took a look at docker images building and spotted this problem:

```
https://github.com/ColinIanKing/stress-ng/runs/7733122240
2022-08-08T20:16:38.9943560Z #25 2196.7 stress-regs.c:620:40: error: macro "REGS_CHECK" requires 4 arguments, but only 3 given
2022-08-08T20:16:38.9943901Z #25 2196.7   620 |         REGS_CHECK(args, "r14", stash64)
```

So, this patch fixes the compilation error by giving 4 arguments to the macro instead of 3.
Nonetheless, I am not really familiar with register shuffling and power PC architecture, so this is possible this patch will not be correct at runtime.
As a consequence, any feedback is welcomed!

Best regards and thank you in advance.