### PR TITLE
stress-sysinval: fix fstat/fstat64 compat check

### DIFF
--- a/stress-sysinval.c
+++ b/stress-sysinval.c
@@ -590,8 +590,8 @@ static const stress_syscall_arg_t stress_syscall_args[] = {
 	{ SYS(fstat), 2, { ARG_FD, ARG_PTR_WR, 0, 0, 0, 0 } },
 #endif
 #if DEFSYS(fstat64)
-	{ SYS(fstat), 2, { ARG_FD, ARG_PTR, 0, 0, 0, 0 } },
-	{ SYS(fstat), 2, { ARG_FD, ARG_PTR_WR, 0, 0, 0, 0 } },
+	{ SYS(fstat64), 2, { ARG_FD, ARG_PTR, 0, 0, 0, 0 } },
+	{ SYS(fstat64), 2, { ARG_FD, ARG_PTR_WR, 0, 0, 0, 0 } },
 #endif
 #if DEFSYS(fstatat)
 	{ SYS(fstatat), 4, { ARG_DIRFD, ARG_EMPTY_FILENAME, ARG_PTR, ARG_FLAG, 0, 0 } },


### PR DESCRIPTION
It seems that __NR_fstat64 may be defined while __NR_fstat may be
undefined.
Looking at the kernel file 'include/uapi/asm-generic/unistd.h' this looks
possible where there is a 32-bit arch.

In any case, checking that __NR_fstat64 exists/has-a-value when adding it
to the table looks like a good idea, vs adding __NR_fstat.

This was found when updating stress-ng here:
  https://github.com/openwrt/packages/pull/19048

The ARCHS (or ARC) build is failing. No idea why it's the only one.
But this patch fixes it.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>