### PR TITLE
Makefile: fix build with kernel < 5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,7 @@ stress-personality.c: personality.h
 #
 io-uring.h:
 	$(PRE_V)$(CPP) $(CFLAGS) core-io-uring.c  | $(GREP) IORING_OP | sed 's/,//' | \
-	sed 's/IORING_OP_/#define HAVE_IORING_OP_/' > io-uring.h
+	sed 's/.*\(IORING_OP_.*\)/#define HAVE_\1/' > io-uring.h
 	$(PRE_Q)echo "MK io-uring.h"
 
 stress-io-uring.c: io-uring.h

--- a/stress-io-uring.c
+++ b/stress-io-uring.c
@@ -311,7 +311,11 @@ static inline int stress_io_uring_complete(
 			break;
 
 		cqe = &cring->cqes[head & *submit->cq_ring.ring_mask];
-		if ((cqe->res < 0) && (opcode != IORING_OP_FALLOCATE)) {
+		if ((cqe->res < 0)
+#ifdef HAVE_IORING_OP_FALLOCATE
+			&& (opcode != IORING_OP_FALLOCATE)
+#endif
+		) {
 			const int err = abs(cqe->res);
 
 			/* Silently ignore EOPNOTSUPP completion errors */


### PR DESCRIPTION
Fix the following build failure with kernel >= 5.1 and < 5.5 (i.e. before https://github.com/torvalds/linux/commit/9e3aa61ae3e01ce1ce6361a41ef725e1f4d1d2bf) raised since version 0.11.21 and https://github.com/ColinIanKing/stress-ng/commit/3d6fccdbe53d0cbcb75dd4b91571aaaae7ee1ad4:

```
In file included from stress-io-uring.c:26:
io-uring.h:1:9: error: macro names must be identifiers
    1 | #define #define HAVE_IORING_OP_NOP 0
      |         ^
```

Moreover, `IORING_OP_FALLOCATE` is not available before kernel 5.6 and https://github.com/torvalds/linux/commit/d63d1b5edb7b832210bfde587ba9e7549fa064eb

Fixes:
 - http://autobuild.buildroot.org/results/1bf3f2bbc849bdce531d56b1024fa87f0c1ae667

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>