### PR TITLE
Fix buffer overflow if tty return width is zero

### DIFF
--- a/core-helper.c
+++ b/core-helper.c
@@ -3110,7 +3110,7 @@ int stress_tty_width(void)
 	if (ret < 0)
 		return max_width;
 	ret = (int)ws.ws_col;
-	if ((ret < 0) || (ret > 1024))
+	if ((ret <= 0) || (ret > 1024))
 		return max_width;
 	return ret;
 #else


### PR DESCRIPTION
In some cases (like a console serial on small embedded Linux system) TIOCGWINSZ may return zero, leading to an overflow in some functions like stress_usage_help