### PR TITLE
core-thermal-zone: fix the average temperature calculation

### DIFF
--- a/core-thermal-zone.c
+++ b/core-thermal-zone.c
@@ -233,6 +233,8 @@ void stress_tz_dump(FILE *yaml, stress_stressor_t *stressors_list)
 
 		for (i = 0; i < n; i++) {
 			tz_info = tz_infos[i];
+			total = 0;
+			count = 0;
 
 			for (j = 0; j < ss->started_instances; j++) {
 				const uint64_t temp =


### PR DESCRIPTION
Hi,
I was playing around with the `--tz` option, and I noticed that the readings were quite off on my system. They didn't even match what I could read in `/sys/class/thermal/*/temp`.

So I made a simple:
```c
fprintf(stderr, "Current reading (%s - type: %s): %" PRIu64 "\n",
    path, tz_info->type, tz->tz_stat[i].temperature);
```

inside `stress_tz_get_temperatures()` to see the values I was reading, which I got the following output:

```text
$ ./stress-ng --cpu 0 --tz -t 1
stress-ng: info:  [6738] setting to a 1 second run per stressor
stress-ng: info:  [6738] dispatching hogs: 4 cpu
Current reading (/sys/class/thermal/thermal_zone4/temp - type: iwlwifi_1): 0
Current reading (/sys/class/thermal/thermal_zone4/temp - type: iwlwifi_1): 0
Current reading (/sys/class/thermal/thermal_zone1/temp - type: acpitz): 27800
Current reading (/sys/class/thermal/thermal_zone3/temp - type: x86_pkg_temp): 65000
Current reading (/sys/class/thermal/thermal_zone1/temp - type: acpitz): 27800
Current reading (/sys/class/thermal/thermal_zone0/temp - type: pch_skylake): 47500
Current reading (/sys/class/thermal/thermal_zone3/temp - type: x86_pkg_temp): 65000
Current reading (/sys/class/thermal/thermal_zone2/temp - type: acpitz): 29800
Current reading (/sys/class/thermal/thermal_zone0/temp - type: pch_skylake): 47500
Current reading (/sys/class/thermal/thermal_zone2/temp - type: acpitz): 29800
Current reading (/sys/class/thermal/thermal_zone4/temp - type: iwlwifi_1): 0
Current reading (/sys/class/thermal/thermal_zone1/temp - type: acpitz): 27800
Current reading (/sys/class/thermal/thermal_zone3/temp - type: x86_pkg_temp): 65000
Current reading (/sys/class/thermal/thermal_zone0/temp - type: pch_skylake): 47500
Current reading (/sys/class/thermal/thermal_zone2/temp - type: acpitz): 29800
Current reading (/sys/class/thermal/thermal_zone4/temp - type: iwlwifi_1): 0
Current reading (/sys/class/thermal/thermal_zone1/temp - type: acpitz): 27800
Current reading (/sys/class/thermal/thermal_zone3/temp - type: x86_pkg_temp): 65000
Current reading (/sys/class/thermal/thermal_zone0/temp - type: pch_skylake): 47500
Current reading (/sys/class/thermal/thermal_zone2/temp - type: acpitz): 29800
stress-ng: info:  [6738] cpu:
stress-ng: info:  [6738]               acpitz0   29.80 C (302.95 K)
stress-ng: info:  [6738]               acpitz1   28.80 C (301.95 K)
stress-ng: info:  [6738]            iwlwifi_1   19.20 C (292.35 K)
stress-ng: info:  [6738]          pch_skylake   26.27 C (299.42 K)
stress-ng: info:  [6738]         x86_pkg_temp   34.02 C (307.17 K)
stress-ng: info:  [6738] successful run completed in 1.01s
```
The readings were right, but the output was not:
- `iwlwifi_1` should be 0
- `pch_skylake` should be 47.5c
- `x86_pkg_temp` should be 65c
and etc.

In `stress_tz_dump()`, I realized that the accumulated value of each reading was not reset during the average temperature calculation, causing the subsequent temperatures (from another thermal zone) to consider the previous values, resulting in incorrect results.

This is the output I get now:
```text
$ ./stress-ng --cpu 0 --tz -t 1
stress-ng: info:  [6938] setting to a 1 second run per stressor
stress-ng: info:  [6938] dispatching hogs: 4 cpu
stress-ng: info:  [6938] cpu:
stress-ng: info:  [6938]               acpitz0   29.80 C (302.95 K)
stress-ng: info:  [6938]               acpitz1   27.80 C (300.95 K)
stress-ng: info:  [6938]          pch_skylake   47.25 C (320.40 K)
stress-ng: info:  [6938]         x86_pkg_temp   64.00 C (337.15 K)
stress-ng: info:  [6938] successful run completed in 1.01s
```