### PR TITLE
C99 compatibility fixes

### DIFF
--- a/test/test-aligned-alloc.c
+++ b/test/test-aligned-alloc.c
@@ -16,6 +16,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  *
  */
+
+#define _GNU_SOURCE
+
 #include <stdlib.h>
 
 int main(void)

--- a/test/test-fchmodat.c
+++ b/test/test-fchmodat.c
@@ -18,7 +18,7 @@
  *
  */
 
-#include <unistd.h>
+#include <sys/stat.h>
 
 int main(void)
 {

--- a/test/test-float.c
+++ b/test/test-float.c
@@ -58,7 +58,10 @@
 		b = d - (_type)1.0L;                    \
 	} while (0)
 
-static FLOAT HOT OPTIMIZE3 test(void)
+/* Avoid implicit int in the definition of test even if FLOAT is not known. */
+typedef FLOAT float_type;
+
+static float_type HOT OPTIMIZE3 test(void)
 {
 	FLOAT a = 0.0, b = 0.0, c = 0.0, d = 0.0;
 

--- a/test/test-pidfd-getfd.c
+++ b/test/test-pidfd-getfd.c
@@ -20,6 +20,10 @@
 
 #define _GNU_SOURCE
 
+#if defined(__has_include) && __has_include(<sys/pidfd.h>)
+#include <sys/pidfd.h>
+#endif
+
 int main(void)
 {
 	/* We don't care about the args, we just want to see if it links */


### PR DESCRIPTION
This is related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC

The first three commits are required to avoid a sudden `config.h` change with future compilers which do not support implicit function declarations by default (a C language feature that was removed in 1999).

The last commit about implicit int is more speculative: there, the failure is actually expected (say for `__fp16` on x86-64), but due to the way the test is written, the failing test tickles and implicit int error (another feature removed in 1999). As part of our efforts, we need to monitor such errors very closely, hence the desire to avoid them if at all possible.