### PR TITLE
Pass LD_GOLD=1 via makefile to enable gold linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,13 @@ endif
 #CFLAGS += -Weverything
 #endif
 
+#
+# Use gold linker
+#
+ifeq ($(LD_GOLD),1)
+LDFLAGS += -fuse-ld=gold
+endif
+
 GREP = grep
 #
 # SunOS requires special grep for -e support


### PR DESCRIPTION
Current logic prefers gold if a toolchain has gold linker installed and does not offer any option to chose default linker which might not be gold linker. Its better to pass this control to user instead of auto detecting and deciding.

Signed-off-by: Khem Raj <raj.khem@gmail.com>