### PR TITLE
test-float: Make variables global

### DIFF
--- a/test/test-float.c
+++ b/test/test-float.c
@@ -61,10 +61,9 @@
 /* Avoid implicit int in the definition of test even if FLOAT is not known. */
 typedef FLOAT float_type;
 
+FLOAT a = 0.0, b = 0.0, c = 0.0, d = 0.0;
 static float_type HOT OPTIMIZE3 test(void)
 {
-	FLOAT a = 0.0, b = 0.0, c = 0.0, d = 0.0;
-
 	float_ops(FLOAT, a, b, c, d, sin, cos);
 	float_ops(FLOAT, a, b, c, d, sinl, cosl);
 


### PR DESCRIPTION
Latest clang ( clang 16+ ) is able to optimize everything out when -O2 is used and as a result build succeeds and test output comes out to be wrong. Therefore make the variables global, so clang does not optimize away the functions

Signed-off-by: Khem Raj <raj.khem@gmail.com>