### PR TITLE
Fix mktemp file leak

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -100,7 +100,7 @@ define check_tmp
 				echo "CONFIG_CFLAGS += $7" >> $(CONFIGS)/$2; \
 			fi; \
 			if [ -n "$4" ]; then \
-				for I in $(4); do \
+				for I in $4; do \
 					echo "CONFIG_LDFLAGS += $$I" >> $(CONFIGS)/$2; \
 				done; \
 			fi; \
@@ -198,19 +198,19 @@ endef
 #
 define check_header_tmp
 	@if [ ! -f $(CONFIGS)/$2 ]; then \
-		echo "#include <stdio.h>" > $(3).c; \
-		echo "#include <sys/types.h>" >> $(3).c; \
-		for I in $(1); do \
-			echo "#include <$$I>" >> $(3).c; \
+		echo "#include <stdio.h>" > $3.c; \
+		echo "#include <sys/types.h>" >> $3.c; \
+		for I in $1; do \
+			echo "#include <$$I>" >> $3.c; \
 		done; \
-		$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $(3).o $(3).c 2> /dev/null || true; \
-		if [ -f $(3).o ]; then \
+		$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $3.o $3.c 2> /dev/null || true; \
+		if [ -f $3.o ]; then \
 			echo "using $1 ... yes"; \
 			echo "" >> $(CONFIGS)/$2; \
 		else \
 			echo "using $1 ... no"; \
 		fi; \
-		rm -f $(3).o $(3).c; \
+		rm -f $3.o $3.c; \
 		touch $(CONFIGS)/$2; \
 	fi
 endef
@@ -227,13 +227,13 @@ endef
 define check_ld_tmp
 	@if [ ! -f $(CONFIGS)/$2 ]; then \
 		$(CC) -fuse-ld=$3 $(CFLAGS) $(CPPFLAGS) $(DIR)/$1.c -o $1 2> /dev/null || true; \
-		if [ -f $(1) ]; then \
+		if [ -f $1 ]; then \
 			echo "using -fuse-ld=$3 ... yes"; \
 			echo "CONFIG_LDFLAGS += -fuse-ld=$3" >> $(CONFIGS)/$2; \
 		else \
 			echo "using -fuse-ld=$3 ... no"; \
 		fi; \
-		rm -f $(1); \
+		rm -f $1; \
 		touch $(CONFIGS)/$2; \
 	fi
 endef

--- a/Makefile.config
+++ b/Makefile.config
@@ -198,8 +198,8 @@ endef
 #
 define check_header_tmp
 	@if [ ! -f $(CONFIGS)/$2 ]; then \
-		echo "#include <stdio.h>" > $(3).c;	\
-		echo "#include <sys/types.h>" >> $(3).c;	\
+		echo "#include <stdio.h>" > $(3).c; \
+		echo "#include <sys/types.h>" >> $(3).c; \
 		for I in $(1); do \
 			echo "#include <$$I>" >> $(3).c; \
 		done; \
@@ -1105,7 +1105,7 @@ VECMATH:
 VLA_ARG:
 	$(call check,test-vla-arg,HAVE_VLA_ARG,variable length array function args)
 
-types:	\
+types: \
 	configdir \
 	COMPLEX DATTR_T DVD_AUTHINFO DVD_STRUCT FLOAT_DECIMAL32 FLOAT_DECIMAL64 \
 	FLOAT_DECIMAL128 FLOAT16 FLOAT32 FLOAT64 FLOAT80 FLOAT128 ITIMER_WHICH_T \

--- a/Makefile.config
+++ b/Makefile.config
@@ -87,13 +87,12 @@ comma = ,
 # $5 = cflags required for test
 # $6 = target clone settings
 # $7 = cflags to be added to CONFIG_CFLAGS and test
-# $8 = temp name
+# $8 = temp file
 #
 define check_tmp
 	@if [ ! -f $(CONFIGS)/$2 ]; then \
-		rm -f $8.o; \
-		$(CC) $(CFLAGS) $(CPPFLAGS) -Itest $5 $7 -DTARGET_CLONE=$6 $(DIR)/$1.c $4 -o $8.o $(LDFLAGS) 2> /dev/null || true ; \
-		if [ -f $8.o ]; then \
+		$(CC) $(CFLAGS) $(CPPFLAGS) -Itest $5 $7 -DTARGET_CLONE=$6 $(DIR)/$1.c $4 -o $8 $(LDFLAGS) 2> /dev/null || true ; \
+		if [ -s $8 ]; then \
 			echo "using $3 ... yes"; \
 			echo "# using $2" >> $(CONFIGS)/$2; \
 			if [ -n "$7" ]; then \
@@ -109,7 +108,7 @@ define check_tmp
 		fi; \
 		touch $(CONFIGS)/$2; \
 	fi
-	@rm -f $8.o
+	@rm -f $8
 endef
 
 define check
@@ -120,13 +119,12 @@ endef
 # $1 = float type
 # $2 = HAVE config name
 # $3 = message
-# $4 = temp name
+# $4 = temp file
 #
 define check_float_tmp
 	@if [ ! -f $(CONFIGS)/$2 ]; then \
-		rm -rf $4; \
 		$(CC) $(CFLAGS) $(CPPFLAGS) -DFLOAT=$1 -o $4 $(DIR)/test-float.c -lm 2> /dev/null || true; \
-		if [ -f $4 ]; then \
+		if [ -s $4 ]; then \
 			echo "using $3 ... yes"; \
 			echo "" >> $(CONFIGS)/$2; \
 		else \
@@ -134,7 +132,7 @@ define check_float_tmp
 		fi; \
 	fi
 	@touch $(CONFIGS)/$2
-	@rm -rf $4
+	@rm -f $4
 endef
 
 define check_float
@@ -145,12 +143,12 @@ endef
 # $1 = test program
 # $2 = HAVE config name
 # $3 = message
-# $4 = temp name
+# $4 = temp file
 #
 define check_vecmath_tmp
 	@if [ ! -f $(CONFIGS)/$2 ]; then \
-		$(CC) $(CFLAGS) $(CPPFLAGS) -Itest -DHAVE_VECMATH -c -o $4.o $1.c 2> /dev/null || true; \
-		if [ -f $4.o ]; then \
+		$(CC) $(CFLAGS) $(CPPFLAGS) -Itest -DHAVE_VECMATH -c -o $4 $1.c 2> /dev/null || true; \
+		if [ -s $4 ]; then \
 			echo "using $3 ... yes"; \
 			echo "" >> $(CONFIGS)/$2; \
 		else \
@@ -158,7 +156,7 @@ define check_vecmath_tmp
 		fi; \
 	fi
 	@touch $(CONFIGS)/$2
-	@rm -rf $4.o
+	@rm -f $4
 endef
 
 define check_vecmath
@@ -194,29 +192,29 @@ endef
 #
 # $1 = header file
 # $2 = HAVE config name
-# $3 = tmp name
+# $3 = temp directory
 #
 define check_header_tmp
 	@if [ ! -f $(CONFIGS)/$2 ]; then \
-		echo "#include <stdio.h>" > $3.c; \
-		echo "#include <sys/types.h>" >> $3.c; \
+		echo "#include <stdio.h>" >> $3/a.c; \
+		echo "#include <sys/types.h>" >> $3/a.c; \
 		for I in $1; do \
-			echo "#include <$$I>" >> $3.c; \
+			echo "#include <$$I>" >> $3/a.c; \
 		done; \
-		$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $3.o $3.c 2> /dev/null || true; \
-		if [ -f $3.o ]; then \
+		$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $3/a.o $3/a.c 2> /dev/null || true; \
+		if [ -f $3/a.o ]; then \
 			echo "using $1 ... yes"; \
 			echo "" >> $(CONFIGS)/$2; \
 		else \
 			echo "using $1 ... no"; \
 		fi; \
-		rm -f $3.o $3.c; \
+		rm -rf $3; \
 		touch $(CONFIGS)/$2; \
 	fi
 endef
 
 define check_header
-	$(call check_header_tmp,$1,$2,$(shell mktemp))
+	$(call check_header_tmp,$1,$2,$(shell mktemp -d))
 endef
 
 #


### PR DESCRIPTION
I noticed a large number of empty files (736 to be exact) in `/tmp` after building stress-ng today. The changes in 7d0627d1 introduced this issue. `mktemp` *creates* a safe temporary file and prints its name, but the created file is never used or removed. I'm guessing the intent was to use `mktemp -u` to simply generate a filename prefix, but this is a bad idea. Quoting the GNU coreutils manual:

> Older scripts used to create temporary files by simply joining the name of the program with the process id (‘$$’) as a suffix. However, that naming scheme is easily predictable, and suffers from a race condition where the attacker can create an appropriately named symbolic link, such that when the script then opens a handle to what it thought was an unused file, it is instead modifying an existing file. Using the same scheme to create a directory is slightly safer, since the mkdir will fail if the target already exists, but it is still inferior because it allows for denial of service attacks. Therefore, modern scripts should use the mktemp command to guarantee that the generated name will be unpredictable, and that knowledge of the temporary file name implies that the file was created by the current script and cannot be modified by other users.

> ‘-u’
> ‘--dry-run’
> Generate a temporary name that does not name an existing file, without changing the file system contents. Using the output of this command to create a new file is inherently unsafe, as there is a window of time between generating the name and using it where another process can create an object by the same name.

In fact, the current implementation is *worse* than using `-u` as the file is actually created, allowing an attacker to easily predict the filenames used.

These changes make `Makefile.config` use the files created by `mktemp` properly and avoid polluting the file system. Some logic changes were needed (checking for non-empty files vs existance). I'd be happy to split the style change commits into a separate PR if you'd prefer.