### PR TITLE
Include sys/futex.h for clock_adjtime

### DIFF
--- a/core-shim.c
+++ b/core-shim.c
@@ -66,6 +66,10 @@ UNEXPECTED
 #include <sys/prctl.h>
 #endif
 
+#if defined(HAVE_SYS_TIMEX_H)
+#include <sys/timex.h>
+#endif
+
 #if defined(HAVE_SYS_RANDOM_H)
 #include <sys/random.h>
 #endif


### PR DESCRIPTION
Fixes
core-shim.c:1942:9: error: call to undeclared function 'clock_adjtime'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

Signed-off-by: Khem Raj <raj.khem@gmail.com>