### PR TITLE
stress-mmap: fix build with HAVE_SYSCALL or __NR_mmap2 is undefined

### DIFF
--- a/stress-mmap.c
+++ b/stress-mmap.c
@@ -805,7 +805,9 @@ static int stress_mmap(const stress_args_t *args)
 		context.mmap_file = true;
 
 	if (mmap_mmap2) {
-#if defined(HAVE_MMAP2)
+#if defined(HAVE_MMAP2) && \
+    defined(HAVE_SYSCALL) && \
+    defined(__NR_mmap2)
 		context.mmap = (mmap_func_t)mmap2_try;
 #else
 		if (args->instance == 0)


### PR DESCRIPTION
Commit afae500a added macro tests for defined(HAVE_SYSCALL) and system call numbers.

More specifically, in stress-mmap.c, function mmap2_try() was defined only if __NR_mmap2 is defined.  See:
https://github.com/ColinIanKing/stress-ng/commit/afae500a23b198b9df421ad0fd9270fcdf65c3fb#diff-ffb0db2473f6c5e1b93dd33bce389ee836671a628fff9f903d097733f7ddfc9c

This commit forgot to replicate the same test when the mmap2_try() function is used later at:
https://github.com/ColinIanKing/stress-ng/blob/50f3ef2560e928c4694894be0bb652e663af5076/stress-mmap.c#L754

When HAVE_SYSCALL or __NR_mmap2 is undefined, compilation fails with:

    stress-mmap.c: In function 'stress_mmap':
    stress-mmap.c:809:31: error: 'mmap2_try' undeclared (first use in this function); did you mean 'mmap_prot'?
       context.mmap = (mmap_func_t)mmap2_try;
                                   ^~~~~~~~~
                                   mmap_prot
    stress-mmap.c:809:31: note: each undeclared identifier is reported only once for each function it appears in

This patch fixes this issue.