### PR TITLE
stress-regs: fix build on riscv32

### DIFF
--- a/stress-regs.c
+++ b/stress-regs.c
@@ -473,7 +473,7 @@ do {			\
 }
 #endif
 
-#if defined(STRESS_ARCH_RISCV)
+#if defined(STRESS_ARCH_RISCV) && (__riscv_xlen == 64)
 
 #define STRESS_REGS_HELPER
 /*


### PR DESCRIPTION
RISC-V register test routine is using 64bit registers only. When compiling on 32bit RISC-V, compilation fails with output:

    stress-regs.c: In function 'stress_regs_helper':
    stress-regs.c:485:27: error: register specified for 's1' isn't suitable for data type
      485 |         register uint64_t s1  __asm__("s1")  = v;
          |                           ^~
    stress-regs.c:495:27: error: register specified for 's11' isn't suitable for data type
      495 |         register uint64_t s11 __asm__("s11") = s1 ^ 0xa5a5a5a5a5a5a5a5ULL;
          |                           ^~~

This patch fix this issue by protecting the stress_regs_helper() function with an additional test, to restrict to 64bit.