### PR TITLE
Populate jmp_env before it could be used

### DIFF
--- a/stress-cyclic.c
+++ b/stress-cyclic.c
@@ -770,12 +770,12 @@ again:
 		(void)setrlimit(RLIMIT_RTTIME, &rlim);
 #endif
 
-		if (stress_sighandler(args->name, SIGXCPU, stress_rlimit_handler, &old_action_xcpu) < 0)
-			goto tidy;
-
 		ret = sigsetjmp(jmp_env, 1);
 		if (ret)
 			goto tidy_ok;
+
+		if (stress_sighandler(args->name, SIGXCPU, stress_rlimit_handler, &old_action_xcpu) < 0)
+			goto tidy;
 
 #if defined(HAVE_SCHED_GET_PRIORITY_MIN) &&	\
     defined(HAVE_SCHED_GET_PRIORITY_MAX)

--- a/stress-heapsort.c
+++ b/stress-heapsort.c
@@ -99,10 +99,6 @@ static int stress_heapsort(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-	if (stress_sighandler(args->name, SIGALRM, stress_heapsort_handler, &old_action) < 0) {
-		free(data);
-		return EXIT_FAILURE;
-	}
 
 	ret = sigsetjmp(jmp_env, 1);
 	if (ret) {
@@ -111,6 +107,11 @@ static int stress_heapsort(const stress_args_t *args)
 		 */
 		(void)stress_sigrestore(args->name, SIGALRM, &old_action);
 		goto tidy;
+	}
+
+	if (stress_sighandler(args->name, SIGALRM, stress_heapsort_handler, &old_action) < 0) {
+		free(data);
+		return EXIT_FAILURE;
 	}
 
 	stress_sort_data_int32_init(data, n);

--- a/stress-list.c
+++ b/stress-list.c
@@ -547,11 +547,6 @@ static int stress_list(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-	if (stress_sighandler(args->name, SIGALRM, stress_list_handler, &old_action) < 0) {
-		free(entries);
-		return EXIT_FAILURE;
-	}
-
 	ret = sigsetjmp(jmp_env, 1);
 	if (ret) {
 		/*
@@ -559,6 +554,10 @@ static int stress_list(const stress_args_t *args)
 		 */
 		(void)stress_sigrestore(args->name, SIGALRM, &old_action);
 		goto tidy;
+	}
+	if (stress_sighandler(args->name, SIGALRM, stress_list_handler, &old_action) < 0) {
+		free(entries);
+		return EXIT_FAILURE;
 	}
 
 	v = 0;

--- a/stress-mergesort.c
+++ b/stress-mergesort.c
@@ -102,14 +102,6 @@ static int stress_mergesort(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-#if !defined(__OpenBSD__) &&	\
-    !defined(__NetBSD__)
-	if (stress_sighandler(args->name, SIGALRM, stress_mergesort_handler, &old_action) < 0) {
-		free(data);
-		return EXIT_FAILURE;
-	}
-#endif
-
 	ret = sigsetjmp(jmp_env, 1);
 	if (ret) {
 		/*
@@ -118,6 +110,15 @@ static int stress_mergesort(const stress_args_t *args)
 		(void)stress_sigrestore(args->name, SIGALRM, &old_action);
 		goto tidy;
 	}
+
+
+#if !defined(__OpenBSD__) &&	\
+    !defined(__NetBSD__)
+	if (stress_sighandler(args->name, SIGALRM, stress_mergesort_handler, &old_action) < 0) {
+		free(data);
+		return EXIT_FAILURE;
+	}
+#endif
 
 	stress_sort_data_int32_init(data, n);
 	stress_set_proc_state(args->name, STRESS_STATE_RUN);

--- a/stress-qsort.c
+++ b/stress-qsort.c
@@ -334,11 +334,6 @@ static int OPTIMIZE3 stress_qsort(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-	if (stress_sighandler(args->name, SIGALRM, stress_qsort_handler, &old_action) < 0) {
-		free(data);
-		return EXIT_FAILURE;
-	}
-
 	ret = sigsetjmp(jmp_env, 1);
 	if (ret) {
 		/*
@@ -347,6 +342,12 @@ static int OPTIMIZE3 stress_qsort(const stress_args_t *args)
 		(void)stress_sigrestore(args->name, SIGALRM, &old_action);
 		goto tidy;
 	}
+
+	if (stress_sighandler(args->name, SIGALRM, stress_qsort_handler, &old_action) < 0) {
+		free(data);
+		return EXIT_FAILURE;
+	}
+
 
 	stress_sort_data_int32_init(data, n);
 

--- a/stress-radixsort.c
+++ b/stress-radixsort.c
@@ -108,12 +108,6 @@ static int stress_radixsort(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-	if (stress_sighandler(args->name, SIGALRM, stress_radixsort_handler, &old_action) < 0) {
-		free(data);
-		free(text);
-		return EXIT_FAILURE;
-	}
-
 	ret = sigsetjmp(jmp_env, 1);
 	if (ret) {
 		/*
@@ -122,6 +116,13 @@ static int stress_radixsort(const stress_args_t *args)
 		(void)stress_sigrestore(args->name, SIGALRM, &old_action);
 		goto tidy;
 	}
+
+	if (stress_sighandler(args->name, SIGALRM, stress_radixsort_handler, &old_action) < 0) {
+		free(data);
+		free(text);
+		return EXIT_FAILURE;
+	}
+
 
 	for (i = 0; i < 256; i++)
 		revtable[i] = (unsigned char)(255 - i);

--- a/stress-shellsort.c
+++ b/stress-shellsort.c
@@ -149,10 +149,6 @@ static int stress_shellsort(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-	if (stress_sighandler(args->name, SIGALRM, stress_shellsort_handler, &old_action) < 0) {
-		free(data);
-		return EXIT_FAILURE;
-	}
 
 	ret = sigsetjmp(jmp_env, 1);
 	if (ret) {
@@ -161,6 +157,10 @@ static int stress_shellsort(const stress_args_t *args)
 		 */
 		(void)stress_sigrestore(args->name, SIGALRM, &old_action);
 		goto tidy;
+	}
+	if (stress_sighandler(args->name, SIGALRM, stress_shellsort_handler, &old_action) < 0) {
+		free(data);
+		return EXIT_FAILURE;
 	}
 
 	stress_sort_data_int32_init(data, n);

--- a/stress-tree.c
+++ b/stress-tree.c
@@ -959,11 +959,6 @@ static int stress_tree(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-	if (stress_sighandler(args->name, SIGALRM, stress_tree_handler, &old_action) < 0) {
-		free(nodes);
-		return EXIT_FAILURE;
-	}
-
 	ret = sigsetjmp(jmp_env, 1);
 	if (ret) {
 		/*
@@ -972,6 +967,11 @@ static int stress_tree(const stress_args_t *args)
 		(void)stress_sigrestore(args->name, SIGALRM, &old_action);
 		goto tidy;
 	}
+	if (stress_sighandler(args->name, SIGALRM, stress_tree_handler, &old_action) < 0) {
+		free(nodes);
+		return EXIT_FAILURE;
+	}
+
 
 	for (i = 0; i < n; i++)
 		nodes[i].value = (uint32_t)i;


### PR DESCRIPTION
The files in this pull request register a signal handler before the longjmp global is populated.

I have observed a low probability SIGSEGV while executing sequential class runs. 
On investigation of the core dump, I determined that the SIGALRM is arriving after the handler is registered and prior to `sigsetjmp` execution.

This pull request reorders those two operations to prevent the race condition.

