### PR TITLE
Skip some testcases if the parameter --oom-avoid is set

### DIFF
--- a/stress-bigheap.c
+++ b/stress-bigheap.c
@@ -19,10 +19,6 @@
  */
 #include "stress-ng.h"
 
-#if defined(HAVE_MALLOC_H)
-#include <malloc.h>
-#endif
-
 #define MIN_BIGHEAP_GROWTH	(4 * KB)
 #define MAX_BIGHEAP_GROWTH	(64 * MB)
 #define DEFAULT_BIGHEAP_GROWTH	(64 * KB)
@@ -88,15 +84,6 @@ static int stress_bigheap_child(const stress_args_t *args, void *context)
 		if (!keep_stressing(args))
 			goto finish;
 
-		/* Low memory avoidance, re-start */
-		if ((g_opt_flags & OPT_FLAGS_OOM_AVOID) && stress_low_memory((size_t)bigheap_growth)) {
-			free(old_ptr);
-#if defined(HAVE_MALLOC_TRIM)
-			(void)malloc_trim(0);
-#endif
-			old_ptr = 0;
-			size = 0;
-		}
 		size += (size_t)bigheap_growth;
 
 		t = stress_time_now();
@@ -163,6 +150,11 @@ finish:
  */
 static int stress_bigheap(const stress_args_t *args)
 {
+	if (g_opt_flags & OPT_FLAGS_OOM_AVOID) {
+		pr_dbg("The test case stress-ng-%s is skipped because of the parameter --oom-avoid\n", args->name);
+		return EXIT_SUCCESS;
+	}
+
 	return stress_oomable_child(args, NULL, stress_bigheap_child, STRESS_OOMABLE_NORMAL);
 }
 

--- a/stress-brk.c
+++ b/stress-brk.c
@@ -134,10 +134,6 @@ static int OPTIMIZE3 stress_brk_child(const stress_args_t *args, void *context)
 		uint8_t *ptr;
 		double t;
 
-		/* Low memory avoidance, re-start */
-		if ((g_opt_flags & OPT_FLAGS_OOM_AVOID) && stress_low_memory(page_size))
-			VOID_RET(int, shim_brk(start_ptr));
-
 		i++;
 		if (LIKELY(i < 8)) {
 			/* Expand brk by 1 page */
@@ -207,6 +203,11 @@ static int stress_brk(const stress_args_t *args)
 {
 	int rc;
 	brk_context_t brk_context;
+
+	if (g_opt_flags & OPT_FLAGS_OOM_AVOID) {
+		pr_dbg("The test case stress-ng-%s is skipped because of the parameter --oom-avoid\n", args->name);
+		return EXIT_SUCCESS;
+	}
 
 	brk_context.brk_mlock = false;
 	brk_context.brk_notouch = false;

--- a/stress-env.c
+++ b/stress-env.c
@@ -169,6 +169,11 @@ reap:
  */
 static int stress_env(const stress_args_t *args)
 {
+	if (g_opt_flags & OPT_FLAGS_OOM_AVOID) {
+		pr_dbg("The test case stress-ng-%s is skipped because of the parameter --oom-avoid\n", args->name);
+		return EXIT_SUCCESS;
+	}
+
 	return stress_oomable_child(args, NULL, stress_env_child, STRESS_OOMABLE_DROP_CAP | STRESS_OOMABLE_QUIET);
 }
 

--- a/stress-forkheavy.c
+++ b/stress-forkheavy.c
@@ -243,6 +243,11 @@ static int stress_forkheavy(const stress_args_t *args)
 	stress_forkheavy_args_t forkheavy_args;
 	size_t shmall, freemem, totalmem, freeswap, totalswap, min_mem_free;
 
+	if (g_opt_flags & OPT_FLAGS_OOM_AVOID) {
+		pr_dbg("The test case stress-ng-%s is skipped because of the parameter --oom-avoid\n", args->name);
+		return EXIT_SUCCESS;
+	}
+
 	resources = malloc(num_resources * sizeof(*resources));
 	if (!resources) {
 		pr_inf_skip("%s: cannot allocate %zd resource structures, skipping stressor\n",

--- a/stress-mmaphuge.c
+++ b/stress-mmaphuge.c
@@ -117,9 +117,6 @@ static int stress_mmaphuge_child(const stress_args_t *args, void *v_ctxt)
 				flags |= (stress_mwc1() ? MAP_PRIVATE : MAP_SHARED);
 				flags |= stress_mmap_settings[idx].flags;
 
-				if ((g_opt_flags & OPT_FLAGS_OOM_AVOID) && stress_low_memory(page_size))
-					break;
-
 				bufs[i].sz = sz;
 				buf = (uint8_t *)mmap(NULL, sz,
 							PROT_READ | PROT_WRITE,
@@ -202,6 +199,11 @@ static int stress_mmaphuge(const stress_args_t *args)
 	stress_mmaphuge_context_t ctxt;
 
 	int ret;
+
+	if (g_opt_flags & OPT_FLAGS_OOM_AVOID) {
+		pr_dbg("The test case stress-ng-%s is skipped because of the parameter --oom-avoid\n", args->name);
+		return EXIT_SUCCESS;
+	}
 
 	ctxt.mmaphuge_mmaps = MAX_MMAP_BUFS;
 	(void)stress_get_setting("mmaphuge-mmaps", &ctxt.mmaphuge_mmaps);

--- a/stress-resources.c
+++ b/stress-resources.c
@@ -61,6 +61,11 @@ static int stress_resources(const stress_args_t *args)
 	const size_t num_resources = MAX_LOOPS;
 	pid_t *pids;
 
+	if (g_opt_flags & OPT_FLAGS_OOM_AVOID) {
+		pr_dbg("The test case stress-ng-%s is skipped because of the parameter --oom-avoid\n", args->name);
+		return EXIT_SUCCESS;
+	}
+
 	stress_get_memlimits(&shmall, &freemem, &totalmem, &freeswap, &totalswap);
 	min_mem_free = (freemem / 100) * 2;
 	if (min_mem_free < MIN_MEM_FREE)

--- a/stress-sockpair.c
+++ b/stress-sockpair.c
@@ -308,6 +308,11 @@ static int stress_sockpair(const stress_args_t *args)
 {
 	int rc;
 
+	if (g_opt_flags & OPT_FLAGS_OOM_AVOID) {
+		pr_dbg("The test case stress-ng-%s is skipped because of the parameter --oom-avoid\n", args->name);
+		return EXIT_SUCCESS;
+	}
+
 	stress_set_proc_state(args->name, STRESS_STATE_RUN);
 
 	if (stress_sighandler(args->name, SIGPIPE, stress_sighandler_nop, NULL) < 0)


### PR DESCRIPTION
We found if a testcase triggers the oom, it could make the whole system hang with a high rate under the ubuntu core. This issue is very common on ARM or ARM64 platforms, by now we don't even have one ARM/ARM64 platform which could run all stress-ng testcases without system hang under ubuntu core.

The ubuntu core uses squashfs as the mojor filesystem, when the kernel loads the testcase or libraries from block device to the memory via squashfs_readahead()/squashfs_readpage(), if an oom occurs, it will make the system hang by high chance. Please refer to the function out_of_memory() in the oom_kill.c of linux kernel.

Recently a stress-ng parameter --oom-avoid is added, with this parameter, some testcases will monitor the size of freemem and avoid triggering oom, but those testcases still could trigger oom and make the system hang under the ubuntu core. This is because the criteria of low memory is different on differnt platforms, it depends on the size of system memory, the number of cpu, the number of testcase instanace and ..., it is not easy to set a low memory criteria for all cases.

A temporary solution is to skip those testcases if --oom-avoid is set, So far according to my test, there are 7 testcases need to be skipped, if we find more testcases which have this issue in future, we could adjust the skipping list.