### PR TITLE
stress-resources: fix sem-sysv failure due to nonexistent semaphore set

### DIFF
--- a/core-resources.c
+++ b/core-resources.c
@@ -84,8 +84,6 @@ size_t stress_resources_allocate(
 	if ((freemem > 0) && (freemem < min_mem_free))
 		return 0;
 
-	(void)memset(resources, 0, sizeof(*resources) * num_resources);
-
 	for (i = 0; i < num_resources; i++) {
 #if defined(HAVE_MEMFD_CREATE)
 		char name[64];

--- a/stress-resources.c
+++ b/stress-resources.c
@@ -87,6 +87,11 @@ static int stress_resources(const stress_args_t *args)
 		unsigned int i;
 
 		(void)memset(pids, 0, sizeof(*pids));
+		(void)memset(resources, 0, sizeof(*resources) * num_resources);
+
+		for (i = 0; i < num_resources; i++)
+			resources[i].sem_id = -1;
+
 		for (i = 0; i < num_pids; i++) {
 			pid_t pid;
 


### PR DESCRIPTION
There is a corner case that only happens once to cause sem-sysv failure followed by resources as below:

sem-sysv: semop wait failed, errno=22 (Invalid argument)
sem-sysv: semctl IPC_STAT failed, errno=22 (Invalid argument)

When sem-sysv is initialized, the sem_id could be assigned to zero, especially when the fresh booting. After a sequential run till resources, the resources unexpectedly frees the semaphore set with sem_id that is the same id used by sem-sysv, so that sem-sysv happens semaphore operations failed immediately.

To fix the issue, the struct resources array should be initialized before pid group forking, and reset sem_id to -1 per resources to prevent it from getting zero-valued sem_id.