### PR TITLE
snapcraft: remove a duplicated dependent package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,6 @@ parts:
             - libattr1-dev
             - libxxhash-dev
             - libmd-dev
-            - libxxhash-dev
             - on amd64: [ libipsec-mb-dev ]
 
 apps:


### PR DESCRIPTION
Otherwise it will print error log as below when running 'snapcraft remote-build':
Issues while validating snapcraft.yaml: ... has non-unique elements