### PR TITLE
stress-zlib: fix waitpid() interrupted before child finished processing

### DIFF
--- a/stress-zlib.c
+++ b/stress-zlib.c
@@ -1796,7 +1796,7 @@ again:
 		ret = stress_zlib_deflate(args, fds[1], &shared_checksums->deflate);
 		(void)close(fds[1]);
 		(void)shim_kill(pid, SIGALRM);
-		(void)waitpid(pid, &retval, 0);
+		(void)shim_waitpid(pid, &retval, 0);
 	}
 
 	pipe_broken |= shared_checksums->deflate.pipe_broken;


### PR DESCRIPTION
Waiting for other processes could be interrupted. In case of `--verify` it could lead to comparism of unfinished or still processed data. This happens if the parent process is interrupted while waiting for the child to complete. In this special case waitpid returns -1 and errno is set to EINTR. Further informatiuon can be found in `man 3p wait` section `#RETURN VALUE`.

Fixes: 801faa34ecf5 ("stress-zlib: remove blocking complexity by putting checksum in shared memory")