### PR TITLE
stress-cache: Add --cache-size option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ personality.h
 git-commit-id.h
 stress-ng
 *.o
+configs
+@rm
+io-uring.h
+stress-ng.1.gz
+core-perf-event.h
+config.h

--- a/core-helper.c
+++ b/core-helper.c
@@ -1847,6 +1847,10 @@ int stress_cache_alloc(const char *name)
 	char cache_info[512];
 
 	cpu_caches = stress_cpu_cache_get_all_details();
+
+	if (g_shared->mem_cache_size > 0)
+		goto init_done;
+
 	if (!cpu_caches) {
 		if (stress_warn_once())
 			pr_dbg("%s: using defaults, cannot determine cache details\n", name);

--- a/stress-cache.c
+++ b/stress-cache.c
@@ -72,6 +72,7 @@ static uint64_t disabled_flags;
 
 static const stress_help_t help[] = {
 	{ "C N","cache N",	 	"start N CPU cache thrashing workers" },
+	{ NULL,	"cache-size N",	"set cache-size = N [KB] and ignore --cache-level option"},
 #if defined(HAVE_ASM_X86_CLDEMOTE)
 	{ NULL,	"cache-cldemote",	"cache line demote (x86 only)" },
 #endif

--- a/stress-ng.c
+++ b/stress-ng.c
@@ -303,6 +303,7 @@ static const struct option long_options[] = {
 	{ "bsearch-ops",	1,	0,	OPT_bsearch_ops },
 	{ "bsearch-size",	1,	0,	OPT_bsearch_size },
 	{ "cache",		1,	0, 	OPT_cache },
+	{ "cache-size",		1,	0, 	OPT_cache_size},
 	{ "cache-cldemote",	0,	0,	OPT_cache_cldemote },
 	{ "cache-clflushopt",	0,	0,	OPT_cache_clflushopt },
 	{ "cache-clwb",		0,	0,	OPT_cache_clwb },
@@ -3882,6 +3883,11 @@ next_opt:
 			stress_get_processors(&g_opt_parallel);
 			stress_check_max_stressors("all", g_opt_parallel);
 			break;
+		case OPT_cache_size:
+			u64 = stress_get_uint64(optarg);
+			u64 = u64 * 1024;
+			stress_set_setting("cache-size", TYPE_ID_UINT64, &u64);
+			break;
 		case OPT_backoff:
 			i64 = (int64_t)stress_get_uint64(optarg);
 			stress_set_setting_global("backoff", TYPE_ID_INT64, &i64);
@@ -4556,6 +4562,7 @@ int main(int argc, char **argv, char **envp)
 	 *  Allocate shared cache memory
 	 */
 	g_shared->mem_cache_level = DEFAULT_CACHE_LEVEL;
+	(void)stress_get_setting("cache-size", &g_shared->mem_cache_size);
 	(void)stress_get_setting("cache-level", &g_shared->mem_cache_level);
 	g_shared->mem_cache_ways = 0;
 	(void)stress_get_setting("cache-ways", &g_shared->mem_cache_ways);

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -1125,6 +1125,7 @@ typedef enum {
 	OPT_class,
 
 	OPT_cache_ops,
+	OPT_cache_size,
 	OPT_cache_clflushopt,
 	OPT_cache_cldemote,
 	OPT_cache_clwb,


### PR DESCRIPTION
set cache-size = N [KB], and ignore --cache-level option

This commit adds the --cache-size option to the stress-cache tool. 
The --cache-size option allows specifying a custom cache size in kilobytes (KB) and overrides the --cache-level option. 
This enhancement is particularly useful in scenarios where the cache information is missing in the host machine's cache device tree. 

It can be applied in the following situations:

1. When the 'lscpu' command does not display any cache information.
2. When the 'grep . /sys/devices/system/cpu/cpu*/cache/index*/size' command does not provide valid cache details.
3. When running on an ARM QEMU virtual machine.

By introducing this option, users can continue to perform cache stress testing by providing a custom cache size even when the cache device information is inaccessible. This allows for more flexibility and support in various cache-related testing and simulation scenarios.