### PR TITLE
stress-cache: fix the help of the --cache-size option

### DIFF
--- a/stress-cache.c
+++ b/stress-cache.c
@@ -72,7 +72,7 @@ static uint64_t disabled_flags;
 
 static const stress_help_t help[] = {
 	{ "C N","cache N",	 	"start N CPU cache thrashing workers" },
-	{ NULL,	"cache-size N",		"set cache-size = N [KB] and ignore --cache-level option"},
+	{ NULL,	"cache-size N",		"override the default cache size setting to N bytes" },
 #if defined(HAVE_ASM_X86_CLDEMOTE)
 	{ NULL,	"cache-cldemote",	"cache line demote (x86 only)" },
 #endif


### PR DESCRIPTION
fix the help of the --cache-size option from "set cache-size = N [KB] and ignore --cache-level option" to "override the default cache size setting to N bytes"