### PR TITLE
core-asm-generic: reintroduce HAVE_ASM_NOP check

### DIFF
--- a/core-asm-generic.h
+++ b/core-asm-generic.h
@@ -21,6 +21,7 @@
 
 static inline void stress_asm_nop(void)
 {
+#if defined(HAVE_ASM_NOP)
 #if defined(STRESS_ARCH_KVX)
 	/*
 	 * Extra ;; required for KVX to indicate end of
@@ -29,6 +30,7 @@ static inline void stress_asm_nop(void)
 	__asm__ __volatile__("nop\n;;\n");
 #else
 	__asm__ __volatile__("nop;\n");
+#endif
 #endif
 }
 


### PR DESCRIPTION
This was incorrectly removed in https://github.com/ColinIanKing/stress-ng/commit/6df67425a58d27524a8bcceea528fd03e61e240b, and causes compile failures on architectures which have nop instructions requiring additional information (such as ia64, which requires an argument to its nop instruction).