### PR TITLE
stress-pty: don't treat EINTR as failure when tcdrain is interrupted

### DIFF
--- a/stress-pty.c
+++ b/stress-pty.c
@@ -155,7 +155,8 @@ static int stress_pty(const stress_args_t *args)
 #endif
 #if defined(HAVE_TCDRAIN)
 			{
-				if (UNLIKELY(tcdrain(ptys[i].follower) < 0)) {
+				if (UNLIKELY((tcdrain(ptys[i].follower) < 0) &&
+					     (errno != EINTR))) {
 					pr_fail("%s: tcdrain on follower pty failed, errno=%d (%s)\n",
 						args->name, errno, strerror(errno));
 				}


### PR DESCRIPTION
The tcdrain() could be interrupted by signals, so in that case it returns EINTR, but the signal stress-ng received could come from SIGALRM, which was just set by timer. The best practice usually implements retry mechanism but this commit can simply ignore EINTR.