### PR TITLE
stress-vnni: verify if selected method supports intrinsic

### DIFF
--- a/stress-vnni.c
+++ b/stress-vnni.c
@@ -541,7 +541,9 @@ static int stress_vnni(const stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
-	if (vnni_intrinsic && (intrinsic_count == 0)) {
+	if (vnni_intrinsic && (intrinsic_count == 0 ||
+				(vnni_method != 0 /* all */ && !stress_vnni_methods[vnni_method].vnni_intrinsic)
+				)) {
 		pr_inf_skip("%s: no vector neural network instructions available "
 			"and --vmmi-intrinsic selected, skipping stressor\n",
 			args->name);


### PR DESCRIPTION
On a Xeon 6140 with the following flags:
```
fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb cat_l3 cdp_l3 invpcid_single pti intel_ppin ssbd mba ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm cqm mpx rdt_a avx512f avx512dq rdseed adx smap clflushopt clwb intel_pt avx512cd avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local dtherm ida arat pln pts hwp hwp_act_window hwp_pkg_req pku ospke md_clear flush_l1d arch_capabilities
```

vpaddb method works:
```
$ stress-ng --metrics-brief --vnni-method vpaddb --vnni 1 --timeout 1 stress-ng: info:  [725846] setting to a 1 secs run per stressor stress-ng: info:  [725846] dispatching hogs: 1 vnni
stress-ng: metrc: [725846] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s
stress-ng: metrc: [725846]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: metrc: [725846] vnni             448081      1.01      0.99      0.02    442979.71      442911.78
stress-ng: metrc: [725846] miscellaneous metrics:
stress-ng: metrc: [725846] vnni           503335901.06 vpaddb ops per sec (geometric mean of 1 instances)
stress-ng: info:  [725846] skipped: 0
stress-ng: info:  [725846] passed: 1: vnni (1)
stress-ng: info:  [725846] failed: 0
stress-ng: info:  [725846] metrics untrustworthy: 0
stress-ng: info:  [725846] successful run completed in 1.01 secs
```

But not when asking for intrinsic-only mode:
```
$ stress-ng --metrics-brief --vnni-method vpaddb --vnni 1 --timeout 1 --vnni-intrinsic stress-ng: info:  [725860] setting to a 1 secs run per stressor stress-ng: info:  [725860] dispatching hogs: 1 vnni
stress-ng: metrc: [725860] stressor       bogo ops real time  usr time  sys time   bogo ops/s     bogo ops/s
stress-ng: metrc: [725860]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: metrc: [725860] vnni                  0      1.01      0.99      0.02         0.00           0.00
stress-ng: info:  [725860] skipped: 0
stress-ng: info:  [725860] passed: 1: vnni (1)
stress-ng: info:  [725860] failed: 0
stress-ng: info:  [725860] metrics untrustworthy: 0
stress-ng: info:  [725860] successful run completed in 1.01 secs
```

That's because the vpaddb method does not support intrinsic-only mode. But it wasn't check before launch. This commit adds that check.