### PR TITLE
stress-splice: remove "Exercise 1 byte splice, zero flags" call

### DIFF
--- a/stress-splice.c
+++ b/stress-splice.c
@@ -341,10 +341,6 @@ static int stress_splice(const stress_args_t *args)
 		VOID_RET(ssize_t, splice(fd_in, NULL, fds1[1], NULL,
 			1, ~0U));
 
-		/* Exercise 1 byte splice, zero flags */
-		VOID_RET(ssize_t, splice(fd_in, NULL, fds1[1], NULL,
-			1, 0));
-
 		/* Exercise splicing to oneself */
 		off_in = 0;
 		off_out = 0;


### PR DESCRIPTION
This call was added by commit da8c21898 ("stress-splice: exercise splice with some more invalid or untested arguments"), and at the time, the call would fail with EINVAL.

However, since splice() from /dev/zero was implemented (https://lore.kernel.org/lkml/20230919073743.1066313-1-max.kellermann@ionos.com/), each iteration would add an extra byte to the pipe buffer, eventually filling it completely, leaving no room for more data.  Expecting this call to fail (and silently ignoring a false positive) is wrong.

Reported-by: kernel test robot <oliver.sang@intel.com>
Closes: https://lore.kernel.org/oe-lkp/202310172247.b9959bd4-oliver.sang@intel.com