### PR TITLE
stress-led: use shim_strlcpy instead of strlcpy

### DIFF
--- a/stress-led.c
+++ b/stress-led.c
@@ -70,7 +70,7 @@ static char *stress_led_orig_trigger(const char *str)
 	orig = calloc(len, sizeof(*orig));
 	if (!orig)
 		return NULL;
-	strlcpy(orig, start, len);
+	shim_strlcpy(orig, start, len);
 	return orig;
 }
 


### PR DESCRIPTION
Use shim_strlcpy as some systems don't have strlcpy. This commit complements commit b20c717e.