### PR TITLE
stress-physpage fixes

### DIFF
--- a/stress-ng.h
+++ b/stress-ng.h
@@ -26,6 +26,8 @@
 #define _GNU_SOURCE
 #endif
 
+#define _FILE_OFFSET_BITS 	(64)
+
 #if defined(HAVE_FEATURES_H)
 #include <features.h>
 #endif
@@ -73,10 +75,6 @@
     !defined(HAVE_COMPILER_TCC) &&	\
     !defined(_FORTIFY_SOURCE)
 #define _FORTIFY_SOURCE 	(2)
-#endif
-
-#if !defined(_FILE_OFFSET_BITS)
-#define _FILE_OFFSET_BITS 	(64)
 #endif
 
 /* Some Solaris tool chains only define __sun */

--- a/stress-physpage.c
+++ b/stress-physpage.c
@@ -162,7 +162,7 @@ static int stress_virt_to_phys(
 	if (pageinfo & PAGE_PRESENT) {
 		uint64_t page_count;
 		const uint64_t pfn = pageinfo & PFN_MASK;
-		uintptr_t phys_addr = pfn * page_size;
+		uint64_t phys_addr = pfn * page_size;
 
 		phys_addr |= (virt_addr & (page_size - 1));
 		offset = (off_t)(pfn * sizeof(uint64_t));
@@ -183,8 +183,8 @@ static int stress_virt_to_phys(
 			goto err;
 		}
 		if (page_count < 1) {
-			pr_fail("%s: got zero page count for physical address %p\n",
-				args->name, (void *)phys_addr);
+			pr_fail("%s: got zero page count for physical address 0x%" PRIx64 "\n",
+				args->name, phys_addr);
 			goto err;
 		}
 


### PR DESCRIPTION
This fixes some issues I ran into when using stress-physpage on an ARM AARCH64 system with 32bit userspace.

First of all stress-physpage uses uintptr_t for physical addresses. With a 32bit userspace this becomes a 32bit type, but
64bit are needed for the full physical address.

Second issue is introduced recently withcd84c46ce78 ("core-*, stress-*: Add musl-gcc detection and HAVE_COMPILER_MUSL"). This moves inclusion of <features.h> before the definition of _FILE_OFFSET_BITS. As _FILE_OFFSET_BITS is evaluated in <features.h> the order must be reversed again to actually make off_t a 64bit type.