### PR TITLE
stress-acl: Fix stress_acl_info definition

### DIFF
--- a/stress-acl.c
+++ b/stress-acl.c
@@ -496,7 +496,7 @@ stressor_info_t stress_acl_info = {
 	.class = CLASS_FILESYSTEM | CLASS_OS,
 	.opt_set_funcs = opt_set_funcs,
 	.verify = VERIFY_ALWAYS,
-	.help = help
-	.unimplemented_reason = "build without libacl or acl/libacl.h or sys/acl.h";
+	.help = help,
+	.unimplemented_reason = "build without libacl or acl/libacl.h or sys/acl.h"
 };
 #endif


### PR DESCRIPTION
Currently, stress-acl.c doesn't compile due to the missing comma and the unneeded semicolon.

Fixes: 966de78608cd ("stress-acl: add ACL set vs get verification")