### PR TITLE
stress_system_read can write outside of buffer 

### DIFF
--- a/core-helper.c
+++ b/core-helper.c
@@ -2035,8 +2035,6 @@ ssize_t stress_system_read(
 	(void)close(fd);
 	if ((ssize_t)buf_len == ret)
 		buf[buf_len - 1] = '\0';
-	else
-		buf[ret] = '\0';
 
 	return ret;
 }


### PR DESCRIPTION
It is possible for reads from the `/sys` filesystem to rarely return -EBUSY.

When that happens,  `stress_system_read()` will write to a stack location outside the buffer

``` 
        ret = read(fd, buf, buf_len);
        if (UNLIKELY(ret < 0)) {
                buf[0] = '\0';
                ret = -errno;   // SET 
        }
        (void)close(fd);
        if ((ssize_t)buf_len == ret)
                buf[buf_len - 1] = '\0';
        else
                buf[ret] = '\0'; // USE
```
The `ret` value is set to `-EBUSY` at `SET` and then used in the `USE` statement, which will be before the buffer in the stack of the caller.

The corresponding `strace` shows this happening:
```
openat(AT_FDCWD, "/sys/devices/system/cpu/cpu123/cpufreq/scaling_max_freq", O_RDONLY) = 4
read(4, 0x7ffdea07e320, 128)            = -1 EBUSY (Device or resource busy)
close(4)                                = 0
--- SIGSEGV {si_signo=SIGSEGV, si_code=SI_KERNEL, si_addr=NULL} ---
+++ killed by SIGSEGV (core dumped) +++
```

Since the buffer is already set to zero at the beginning with `memset` will already have cleared the buffer, there's no need for the `else`` conditional.  

