### PR TITLE
fix spelling of lsm_list_modules in Makefile.config

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -3467,7 +3467,7 @@ LSM_GET_SELF_ATTR:
 	$(call check,test-lsm_get_self_attr,HAVE_LSM_GET_SELF_ATTR,lsm_get_self_attr)
 
 LSM_LIST_MODULES:
-	$(call check,test-lsm_list_modules,HAVE_LSM_LIST_MODULES,lst_list_modules)
+	$(call check,test-lsm_list_modules,HAVE_LSM_LIST_MODULES,lsm_list_modules)
 
 LOCKF:
 	$(call check,test-lockf,HAVE_LOCKF,lockf)


### PR DESCRIPTION
fix spelling of lsm_list_modules in Makefile.config