### PR TITLE
Fix unterminated cpu-stress if non 0% or 100% load

### DIFF
--- a/stress-cpu.c
+++ b/stress-cpu.c
@@ -3228,7 +3228,7 @@ static int HOT OPTIMIZE3 stress_cpu(stress_args_t *args)
 			/* Bias takes account of the time to do the delay */
 			bias = (t3_wall_clock - t2_wall_clock) - delay;
 		}
-	} while ((rc == EXIT_SUCCESS) || stress_continue(args));
+	} while ((rc == EXIT_SUCCESS) && stress_continue(args));
 
 	if (stress_is_affinity_set() && (args->instance == 0)) {
 		pr_inf("%s: CPU affinity probably set, this can affect CPU loading\n",


### PR DESCRIPTION
Running a non 100% and 0% cpu workoad will make my stress-ng never terminates even if specify a timeout. For example: `./stress-ng  -c 12 -l 70  --cpu-method matrixprod --timeout 10`.

The problem should come from the incorrect condition to end a loop.