### PR TITLE
stress-vnni: force -O2 at -Os/-Oz as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ override CFLAGS += -Wall -Wextra -DVERSION='"$(VERSION)"' -std=gnu99
 #  gcc-13.2, so remove then and ensure at least -O2 is used or
 #  honour flags > -O2 if they are provided
 #
-VNNI_OFLAGS_REMOVE=-O0 -O1 -Og
+VNNI_OFLAGS_REMOVE=-O0 -O1 -Os -Oz -Og
 VNNI_CFLAGS += $(filter-out $(VNNI_OFLAGS_REMOVE),$(CFLAGS))
 
 #


### PR DESCRIPTION
stress-vnni fails to compile with -Os in much the same way as #315. Extend the override introduced in 6e62dc1 ("Makefile: force vnni to be built with at least -O2") to cover -Os & -Oz as well.

Fixes: 6e62dc1 ("Makefile: force vnni to be built with at least -O2")