### PR TITLE
Add a new pci-dev option to specify the pci device

### DIFF
--- a/core-opts.c
+++ b/core-opts.c
@@ -641,6 +641,7 @@ const struct option stress_long_options[] = {
 	{ "parallel",		1,	0,	OPT_all },
 	{ "pathological",	0,	0,	OPT_pathological },
 	{ "pci",		1,	0,	OPT_pci},
+	{ "pci-dev",		1,	0,	OPT_pci_dev},
 	{ "pci-ops",		1,	0,	OPT_pci_ops },
 #if defined(STRESS_PERF_STATS) && 	\
     defined(HAVE_LINUX_PERF_EVENT_H)

--- a/core-opts.h
+++ b/core-opts.h
@@ -938,6 +938,7 @@ typedef enum {
 	OPT_pageswap_ops,
 
 	OPT_pci,
+	OPT_pci_dev,
 	OPT_pci_ops,
 
 	OPT_perf_stats,


### PR DESCRIPTION
I am looking for the functionality to stress the specified PCI bus. This implementation should support this.

A small optimization can be done here to avoid `snprintf()` twice for the path of the PCI device if using the `--pci-dev` option. However, this should have less impact, so I don't do such optimization. Please let me know if you also prefer to add this work as well.