### PR TITLE
mmapfork: add --mmapfork-bytes option to specify mmap size

### DIFF
--- a/core-opts.c
+++ b/core-opts.c
@@ -560,6 +560,7 @@ const struct option stress_long_options[] = {
 	{ "mmapfixed-ops",	1,	0,	OPT_mmapfixed_ops },
 	{ "mmapfork",		1,	0,	OPT_mmapfork },
 	{ "mmapfork-ops",	1,	0,	OPT_mmapfork_ops },
+	{ "mmapfork-bytes",	1,	0,	OPT_mmapfork_bytes},
 	{ "mmaphuge",		1,	0,	OPT_mmaphuge },
 	{ "mmaphuge-file",	0,	0,	OPT_mmaphuge_file },
 	{ "mmaphuge-mlock",	0,	0,	OPT_mmaphuge_mlock },

--- a/core-opts.h
+++ b/core-opts.h
@@ -832,6 +832,7 @@ typedef enum {
 
 	OPT_mmapfork,
 	OPT_mmapfork_ops,
+	OPT_mmapfork_bytes,
 
 	OPT_mmaphuge,
 	OPT_mmaphuge_file,


### PR DESCRIPTION
Default mmapfork region size is 'DRAM_SIZE / (instances * 32) / 2' for each worker. This value can be quite large on systems with a lot of memory. As a result, mmapfork on slow systems may fail to complete in time, if a short timeout is specified.

Add '--mmapfork-bytes' option to specify mmapfork test region size.

Regards,
Sergey