### PR TITLE
stress-cache: check RISCV_HWPROBE_EXT_ZICBOZ support for stress_cache…

### DIFF
--- a/stress-cache.c
+++ b/stress-cache.c
@@ -723,7 +723,8 @@ static void stress_cache_bzero(uint8_t *buffer, const uint64_t buffer_size)
 {
 #if defined(STRESS_ARCH_RISCV) &&	\
     defined(HAVE_ASM_RISCV_CBO_ZERO) &&	\
-    defined(__NR_riscv_hwprobe)
+    defined(__NR_riscv_hwprobe) && \
+    defined(RISCV_HWPROBE_EXT_ZICBOZ)
 	cpu_set_t cpus;
 	struct riscv_hwprobe pair;
 


### PR DESCRIPTION
…_bzero

RISCV_HWPROBE_EXT_ZICBOZ flag from kernel headers on RISC-V was only added in 6.7, test build will fail with an older kernel with:
    error: ‘RISCV_HWPROBE_EXT_ZICBOZ’ undeclared

Check the flag first to fix this issue.

Fixes: f8654a05f4 ("stress-cache: add stress_cache_bzero() to support cache-based bzero")

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>