### PR TITLE
stress-ng: add qnx support

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -31,7 +31,9 @@ endif
 LIB_Z := -lz
 LIB_CRYPT := -lcrypt
 LIB_RT := -lrt
+ifneq ($(findstring nto-qnx,$(CC)),nto-qnx)
 LIB_PTHREAD := -lpthread
+endif
 LIB_AIO := -laio
 LIB_SCTP := -lsctp
 LIB_DL := -ldl
@@ -92,6 +94,10 @@ endif
 
 ifeq ($(shell uname -s),SunOS)
 	CONFIG_LDFLAGS += $(LIB_SOCKET) $(LIB_NSL)
+endif
+
+ifeq ($(findstring nto-qnx,$(CC)),nto-qnx)
+	CONFIG_LDFLAGS += $(LIB_SOCKET)
 endif
 #
 #  This must always come after -pthread so that static linking works

--- a/README.md
+++ b/README.md
@@ -320,6 +320,13 @@ the toolchain (both CC and CXX). For example, a mips64 cross build:
 	STATIC=1 CC=mips64-linux-gnuabi64-gcc CXX=mips64-linux-gnuabi64-g++ make -j $(nproc)
 ```
 
+To perform a cross-compile for qnx, for example, a aarch64 qnx cross build:
+
+```
+    make clean
+    CC=aarch64-unknown-nto-qnx7.1.0-gcc CXX=aarch64-unknown-nto-qnx7.1.0-g++ STATIC=1 make
+```
+
 To build with debug (-g) enabled use:
 ```
 	make clean

--- a/core-helper.c
+++ b/core-helper.c
@@ -2437,7 +2437,10 @@ int stress_sighandler(
 	(void)shim_memset(&new_action, 0, sizeof new_action);
 	new_action.sa_handler = handler;
 	(void)sigemptyset(&new_action.sa_mask);
-	new_action.sa_flags = SA_ONSTACK | SA_NOCLDSTOP;
+	new_action.sa_flags = SA_NOCLDSTOP;
+#if defined(HAVE_SIGALTSTACK)
+	new_action.sa_flags |= SA_ONSTACK;
+#endif
 
 	if (sigaction(signum, &new_action, orig_action) < 0) {
 		pr_fail("%s: sigaction %s: errno=%d (%s)\n",

--- a/core-vmstat.c
+++ b/core-vmstat.c
@@ -316,7 +316,11 @@ char *stress_find_mount_dev(const char *name)
 	else
 		dev = statbuf.st_dev;
 
+#if defined(__QNXNTO__)
+	majdev = makedev(0, major(dev), 0);
+#else
 	majdev = makedev(major(dev), 0);
+#endif
 
 	dir = opendir("/dev");
 	if (!dir)

--- a/stress-stack.c
+++ b/stress-stack.c
@@ -270,7 +270,9 @@ static int stress_stack_child(stress_args_t *args, void *context)
 		(void)shim_memset(&new_action, 0, sizeof new_action);
 		new_action.sa_handler = stress_segvhandler;
 		(void)sigemptyset(&new_action.sa_mask);
+#if defined(HAVE_SIGALTSTACK)
 		new_action.sa_flags = SA_ONSTACK;
+#endif
 
 		if (sigaction(SIGSEGV, &new_action, NULL) < 0) {
 			pr_fail("%s: sigaction on SIGSEGV failed, errno=%d (%s)\n",

--- a/stress-sysinfo.c
+++ b/stress-sysinfo.c
@@ -219,7 +219,11 @@ static int stress_sysinfo(stress_args_t *args)
 			 * Exercise invalid ustat, assuming that major ~0 is
 			 * invalid
 			 */
+#if defined(__QNXNTO__)
+			sbuf.st_dev = makedev(0, ~0, stress_mwc32());
+#else
 			sbuf.st_dev = makedev(~0, stress_mwc32());
+#endif
 			VOID_RET(int, shim_ustat(sbuf.st_dev, &ubuf));
 #endif
 		}

--- a/stress-vma.c
+++ b/stress-vma.c
@@ -261,6 +261,7 @@ static void *stress_vma_munlock(void *ptr)
 	return NULL;
 }
 
+#if defined(HAVE_MADVISE)
 static void *stress_vma_madvise(void *ptr)
 {
 	stress_vma_context_t *ctxt = (stress_vma_context_t *)ptr;
@@ -317,6 +318,7 @@ static void *stress_vma_madvise(void *ptr)
 	}
 	return NULL;
 }
+#endif
 
 #if defined(HAVE_MINCORE)
 static void *stress_vma_mincore(void *ptr)
@@ -449,7 +451,9 @@ static const stress_thread_info_t vma_funcs[] = {
 	{ stress_vma_munmap,	1 },
 	{ stress_vma_mlock,	1 },
 	{ stress_vma_munlock,	1 },
+#if defined(HAVE_MADVISE)
 	{ stress_vma_madvise,	1 },
+#endif
 #if defined(HAVE_MINCORE)
 	{ stress_vma_mincore,	1 },
 #endif


### PR DESCRIPTION
Changes to support qnx,  mainly following points:
1. use "nto-qnx" in compiler name to determine qnx build
2. qnx has no need to link pthread library, the pthread api is in libc, and qnx need link libsocket to support socket api
3. qnx's makedev need three parameters, the first one should be 0 aka ND_LOCAL_NODE,  samba had a similar fixup https://bugzilla.samba.org/show_bug.cgi?id=3806#c0

Not fully tested, following example just work fine on qnx arch64.  
```
stress-ng --cpu 8 --cpu-load 80
stress-ng -c 2 -i 1 -m 1 --vm-bytes 128M -t 2s 
```