### PR TITLE
core-target-clone: fix power9 target build issue

### DIFF
--- a/core-target-clones.h
+++ b/core-target-clones.h
@@ -199,6 +199,8 @@
 #if defined(HAVE_TARGET_CLONES_POWER10)
 #define TARGET_CLONE_POWER10 "cpu=power10",
 #define TARGET_CLONE_USE
+#else
+#define TARGET_CLONE_POWER10
 #endif
 
 #define TARGET_CLONES_ALL	\


### PR DESCRIPTION
Fix the below build issue on Power9 by adding an empty definition for TARGET_CLONE_POWER10.

```
In file included from stress-bitops.c:25:
core-target-clones.h:206:2: error: 'TARGET_CLONE_POWER10' undeclared here (not in a function); did you mean 'TARGET_CLONE_POWER9'?
  206 |  TARGET_CLONE_POWER10 \
      |  ^~~~~~~~~~~~~~~~~~~~
core-target-clones.h:210:52: note: in expansion of macro 'TARGET_CLONES_ALL'
  210 | #define TARGET_CLONES __attribute__((target_clones(TARGET_CLONES_ALL)))
```