### PR TITLE
stress-fp: support bfloat16

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1666,6 +1666,7 @@ VLA_ARG:
 .PHONY: types
 types: \
 	configdir \
+	BF16 \
 	CDROM_BLK \
 	CDROM_MCN \
 	CDROM_MSF \
@@ -1782,6 +1783,9 @@ types: \
 	VT_SIZES \
 	VT_STAT \
 	WINSIZE
+
+BF16:
+	$(call check_float,__bf16,HAVE__bf16,__bf16)
 
 COMPLEX:
 	$(call check,test-complex,HAVE_COMPLEX,complex)

--- a/stress-fp.c
+++ b/stress-fp.c
@@ -43,7 +43,8 @@
 #define STRESS_FP_TYPE_FLOAT80		(7)
 #define STRESS_FP_TYPE_FLOAT128		(8)
 #define STRESS_FP_TYPE_IBM128		(9)
-#define STRESS_FP_TYPE_ALL		(10)
+#define STRESS_FP_TYPE_BF16		(10)
+#define STRESS_FP_TYPE_ALL		(11)
 
 static const stress_help_t help[] = {
 	{ NULL,	"fp N",	 	"start N workers performing floating point math ops" },
@@ -77,6 +78,16 @@ typedef struct {
 		float mul;		/* value to multiply */
 		float mul_rev;		/* value to multiply to revert back */
 	} f;
+#if defined(HAVE__bf16)
+	struct {
+		__bf16 r_init;		/* initialization value for r */
+		__bf16 r[2];		/* result of computation */
+		__bf16 add;		/* value to add */
+		__bf16 add_rev;		/* value to add to revert back */
+		__bf16 mul;		/* value to multiply */
+		__bf16 mul_rev;		/* value to multiply to revert back */
+	} bf16;
+#endif
 #if defined(HAVE_Float16)
 	struct {
 		_Float16 r_init;	/* initialization value for r */
@@ -290,6 +301,12 @@ STRESS_FP_ADD(f, stress_fp_float_add, true)
 STRESS_FP_MUL(f, stress_fp_float_mul, true)
 STRESS_FP_DIV(f, stress_fp_float_div, true)
 
+#if defined(HAVE__bf16)
+STRESS_FP_ADD(bf16, stress_fp_bf16_add, false)
+STRESS_FP_MUL(bf16, stress_fp_bf16_mul, false)
+STRESS_FP_DIV(bf16, stress_fp_bf16_div, false)
+#endif
+
 #if defined(HAVE_Float16)
 STRESS_FP_ADD(f16, stress_fp_float16_add, false)
 STRESS_FP_MUL(f16, stress_fp_float16_mul, false)
@@ -355,6 +372,9 @@ static stress_fp_funcs_t stress_fp_funcs[] = {
 #if defined(HAVE_Float32)
 	{ "float32add",		"float32 add",		stress_fp_float32_add,	STRESS_FP_TYPE_FLOAT32,		0.0, 0.0 },
 #endif
+#if defined(HAVE__bf16)
+	{ "bf16add",		"bf16 add",		stress_fp_bf16_add,	STRESS_FP_TYPE_BF16,		0.0, 0.0 },
+#endif
 #if defined(HAVE_Float16)
 	{ "float16add",		"float16 add",		stress_fp_float16_add,	STRESS_FP_TYPE_FLOAT16,		0.0, 0.0 },
 #endif
@@ -377,6 +397,9 @@ static stress_fp_funcs_t stress_fp_funcs[] = {
 #endif
 #if defined(HAVE_Float32)
 	{ "float32mul",		"float32 multiply",	stress_fp_float32_mul,	STRESS_FP_TYPE_FLOAT32,		0.0, 0.0 },
+#endif
+#if defined(HAVE__bf16)
+	{ "bf16mul",		"bf16 multiply",	stress_fp_bf16_mul,	STRESS_FP_TYPE_BF16,		0.0, 0.0 },
 #endif
 #if defined(HAVE_Float16)
 	{ "float16mul",		"float16 multiply",	stress_fp_float16_mul,	STRESS_FP_TYPE_FLOAT16,		0.0, 0.0 },
@@ -401,6 +424,9 @@ static stress_fp_funcs_t stress_fp_funcs[] = {
 #if defined(HAVE_Float32)
 	{ "float32div",		"float32 divide",	stress_fp_float32_div,	STRESS_FP_TYPE_FLOAT32,		0.0, 0.0 },
 #endif
+#if defined(HAVE__bf16)
+	{ "bf16div",		"bf16 divide",		stress_fp_bf16_div,	STRESS_FP_TYPE_BF16,		0.0, 0.0 },
+#endif
 #if defined(HAVE_Float16)
 	{ "float16div",		"float16 divide",	stress_fp_float16_div,	STRESS_FP_TYPE_FLOAT16,		0.0, 0.0 },
 #endif
@@ -420,6 +446,7 @@ static const fp_type_map_t fp_type_map[] = {
 	{ STRESS_FP_TYPE_LONG_DOUBLE,	"long double" },
 	{ STRESS_FP_TYPE_DOUBLE,	"double" },
 	{ STRESS_FP_TYPE_FLOAT,		"float" },
+	{ STRESS_FP_TYPE_BF16,		"bf16" },
 	{ STRESS_FP_TYPE_FLOAT16,	"float16" },
 	{ STRESS_FP_TYPE_FLOAT32,	"float32" },
 	{ STRESS_FP_TYPE_FLOAT64,	"float64" },
@@ -597,6 +624,12 @@ static int stress_fp(stress_args_t *args)
 		fp_data[i].f.r[0] = (float)ld;
 		fp_data[i].f.r[1] = (float)ld;
 
+#if defined(HAVE__bf16)
+		fp_data[i].bf16.r_init = (__bf16)ld;
+		fp_data[i].bf16.r[0] = (__bf16)ld;
+		fp_data[i].bf16.r[1] = (__bf16)ld;
+#endif
+
 #if defined(HAVE_Float16)
 		fp_data[i].f16.r_init = (_Float16)ld;
 		fp_data[i].f16.r[0] = (_Float16)ld;
@@ -636,6 +669,9 @@ static int stress_fp(stress_args_t *args)
 		fp_data[i].ld.add = ld;
 		fp_data[i].d.add = (double)ld;
 		fp_data[i].f.add = (float)ld;
+#if defined(HAVE__bf16)
+		fp_data[i].bf16.add = (__bf16)ld;
+#endif
 #if defined(HAVE_Float16)
 		fp_data[i].f16.add = (_Float16)ld;
 #endif
@@ -658,6 +694,9 @@ static int stress_fp(stress_args_t *args)
 		fp_data[i].ld.add_rev = ld;
 		fp_data[i].d.add_rev = (double)ld;
 		fp_data[i].f.add_rev = (float)ld;
+#if defined(HAVE__bf16)
+		fp_data[i].bf16.add_rev = (__bf16)ld;
+#endif
 #if defined(HAVE_Float16)
 		fp_data[i].f16.add_rev = (_Float16)ld;
 #endif
@@ -681,6 +720,9 @@ static int stress_fp(stress_args_t *args)
 		fp_data[i].ld.mul = ld;
 		fp_data[i].d.mul = (double)ld;
 		fp_data[i].f.mul = (float)ld;
+#if defined(HAVE__bf16)
+		fp_data[i].bf16.mul = (__bf16)ld;
+#endif
 #if defined(HAVE_Float16)
 		fp_data[i].f16.mul = (_Float16)ld;
 #endif

--- a/stress-ng.1
+++ b/stress-ng.1
@@ -2803,6 +2803,7 @@ float80add	80 bit floating point add
 float64add	64 bit floating point add
 float32add	32 bit binary32 floating point add
 floatadd	floating point add
+bf16add		bf16 floating point add
 doubleadd	double precision floating point add
 ldoubleadd	long double precision floating point add
 float128mul	128 bit floating point multiply
@@ -2811,6 +2812,7 @@ float80mul	80 bit floating point multiply
 float64mul	64 bit floating point multiply
 float32mul	32 bit binary32 floating point multiply
 floatmul	floating point multiply
+bf16mul		bf16 floating point multiply
 doublemul	double precision floating point multiply
 ldoublemul	long double precision floating point multiply
 float128div	128 bit floating point divide
@@ -2819,6 +2821,7 @@ float80div	80 bit floating point divide
 float64div	64 bit floating point divide
 float32div	32 bit binary32 floating point divide
 floatdiv	floating point divide
+bf16div		bf16 floating point divide
 doublediv	double precision floating point divide
 ldoublediv	long double precision floating point divide
 .TE


### PR DESCRIPTION
Run base math ops with bfloat16 if it is available.