### PR TITLE
fix mutexattr protocol do not be set problem

### DIFF
--- a/stress-prio-inv.c
+++ b/stress-prio-inv.c
@@ -403,11 +403,9 @@ static int stress_prio_inv(stress_args_t *args)
 		VOID_RET(int, pthread_mutexattr_setprotocol(&mutexattr, PTHREAD_PRIO_NONE));
 		break;
 #endif
-#if defined(PTHREAD_PRIO_INHERIT)
 	case STRESS_PRIO_INV_TYPE_INHERIT:
 		VOID_RET(int, pthread_mutexattr_setprotocol(&mutexattr, PTHREAD_PRIO_INHERIT));
 		break;
-#endif
 #if defined(PTHREAD_PRIO_PROTECT)
 	case STRESS_PRIO_INV_TYPE_PROTECT:
 		VOID_RET(int, pthread_mutexattr_setprotocol(&mutexattr, PTHREAD_PRIO_PROTECT));


### PR DESCRIPTION
to fix this issue : https://github.com/ColinIanKing/stress-ng/issues/437#issue-2576280901
for version V0.18.00
The origin code expected PTHREAD_PRIO_INHERIT to be defined, but it is not, causing mutexattr protocol to not be set to PTHREAD_PRIO_INHERIT

solve:
Remove the "if defined" marco around pthread_mutexattr_setprotocol