### PR TITLE
problem: fix stress-prio-inv 

### DIFF
--- a/stress-prio-inv.c
+++ b/stress-prio-inv.c
@@ -31,6 +31,7 @@
 */
 
 #define MUTEX_PROCS	(3)
+#define PTHREAD_PRIO_INHERIT 1
 
 #if defined(PTHREAD_PRIO_INHERIT)
 #define STRESS_PRIO_INV_TYPE_INHERIT	(PTHREAD_PRIO_INHERIT)
@@ -472,8 +473,10 @@ reap:
 	}
 #endif
 
-	if ((sched_policy >= 0) &&
-	    (sched_policy == STRESS_PRIO_INV_TYPE_INHERIT) &&
+
+
+	if ((pthread_protocol>= 0) &&
+	    (pthread_protocol == STRESS_PRIO_INV_TYPE_INHERIT) &&
 	    (child_info[2].usage < child_info[0].usage * 0.9) &&
 	    (child_info[0].usage > 1.0)) {
 		pr_warn("%s: mutex priority inheritance appears incorrect, "


### PR DESCRIPTION
1. The origin code expected PTHREAD_PRIO_INHERIT to be defined, but it is not 
solve:  add #define PTHREAD_PRIO_INHERIT 1
3. warning message output have an incorrect precondition, so the warning message will not be printed 
solve: change the condition
