### PR TITLE
core-sched: Add support for sched_ext scheduling policies

### DIFF
--- a/core-sched.c
+++ b/core-sched.c
@@ -36,6 +36,11 @@
 #define SCHED_FLAG_DL_OVERRUN           (0x04)
 #endif
 
+#if defined(__linux__) && !defined(SCHED_EXT)
+#define SCHED_EXT			(7)
+#endif
+
+
 const stress_sched_types_t stress_sched_types[] = {
 #if defined(SCHED_BATCH)
 	{ SCHED_BATCH,		"batch" },
@@ -51,6 +56,9 @@ const stress_sched_types_t stress_sched_types[] = {
 #endif
 #if defined(SCHED_OTHER)
 	{ SCHED_OTHER,		"other" },
+#endif
+#if defined(SCHED_EXT)
+	{ SCHED_EXT,		"sched_ext" },
 #endif
 #if defined(SCHED_RR)
 	{ SCHED_RR,		"rr" },

--- a/stress-cpu-sched.c
+++ b/stress-cpu-sched.c
@@ -111,6 +111,9 @@ static const int normal_policies[] = {
 #if defined(SCHED_BATCH)
 	SCHED_BATCH,
 #endif
+#if defined(SCHED_EXT)
+	SCHED_EXT,
+#endif
 #if defined(SCHED_BATCH) && defined(SCHED_RESET_ON_FORK)
 	SCHED_BATCH | SCHED_RESET_ON_FORK,
 #endif

--- a/stress-race-sched.c
+++ b/stress-race-sched.c
@@ -101,6 +101,9 @@ static const int normal_policies[] = {
 #if defined(SCHED_BATCH)
 		SCHED_BATCH,
 #endif
+#if defined(SCHED_EXT)
+		SCHED_EXT,
+#endif
 #if defined(SCHED_IDLE)
 		SCHED_IDLE,
 #endif

--- a/stress-resched.c
+++ b/stress-resched.c
@@ -66,6 +66,9 @@ static void OPTIMIZE3 NORETURN stress_resched_child(
 #if defined(SCHED_BATCH)
 		SCHED_BATCH,
 #endif
+#if defined(SCHED_EXT)
+		SCHED_EXT,
+#endif
 #if defined(SCHED_IDLE)
 		SCHED_IDLE,
 #endif

--- a/stress-schedmix.c
+++ b/stress-schedmix.c
@@ -380,6 +380,10 @@ static int stress_schedmix_child(stress_args_t *args)
 		case SCHED_BATCH:
 			goto case_sched_other;
 #endif
+#if defined(SCHED_EXT)
+		case SCHED_EXT:
+			goto case_sched_other;
+#endif
 #if defined(SCHED_OTHER)
 		case SCHED_OTHER:
 #endif

--- a/stress-schedpolicy.c
+++ b/stress-schedpolicy.c
@@ -145,6 +145,9 @@ static int stress_schedpolicy(stress_args_t *args)
 #if defined(SCHED_BATCH)
 		case SCHED_BATCH:
 #endif
+#if defined(SCHED_EXT)
+		case SCHED_EXT:
+#endif
 #if defined(SCHED_OTHER)
 		case SCHED_OTHER:
 #endif


### PR DESCRIPTION
Add support for sched_ext scheduling policies. sched_ext is supported in kernel 6.12 and later.

We've been using `stress-ng` quite successfully for testing BPF schedulers for sched_ext in the [scx](https://github.com/sched-ext/scx/) repo. I've attempted to add support for the `sched_ext` scheduling policy. 