### PR TITLE
stress-bitops: add macro to handle undefined return for the ctz(0) case as well

### DIFF
--- a/stress-bitops.c
+++ b/stress-bitops.c
@@ -42,6 +42,10 @@ static const stress_help_t help[] = {
 #define BITOPS_CLZ(x)	(UNLIKELY((x) == 0) ? 32 : __builtin_clz((x)))
 #endif
 
+#if defined(HAVE_BUILTIN_CTZ)
+#define BITOPS_CTZ(x)	(UNLIKELY((x) == 0) ? 32 : __builtin_ctz((x)))
+#endif
+
 static const stress_bitops_method_info_t bitops_methods[];
 
 static int stress_bitops_all(const char *name, uint32_t *count);
@@ -361,7 +365,7 @@ static int OPTIMIZE3 TARGET_CLONES stress_bitops_ctz(const char *name, uint32_t 
 
 #if defined(HAVE_BUILTIN_CTZ)
 		/* #4, Count trailing zeros, ctz method */
-		c2 = __builtin_ctz((unsigned int)v);
+		c2 = BITOPS_CTZ((unsigned int)v);
 		sum += c2;
 		if (UNLIKELY(c1 != c2)) {
 			pr_fail("%s: ctz builtin_ctz method failure, value 0x%" PRIx32 ", c1 = 0x%" PRIx32 ", c2 = 0x%" PRIx32 "\n",


### PR DESCRIPTION
in the 0 case, recent gcc versions produce code that is guaranteed to fail in nonsensical ways, producing messages such as:

    bitops: ctz builtin_ctz method failure, value 0x0, c1 = 0x20, c2 = 0x20

even if it emits a `tzcnt`, that is guaranteed to work in the 0 case.

For example, a minimal test program like

    #ifdef FIX
    #define BITOPS_CTZ(x)       (((x) == 0) ? 32 : __builtin_ctz((x)))
    #else
    #define BITOPS_CTZ(x)       (__builtin_ctz((x)))
    #endif

    void pr_fail(unsigned);

    int test(unsigned v) {
        unsigned c1, c2, sum = 0, tmp;
        /* #1 Count trailing zeros, naive method */
        if (v == 0) {
            c1 = 32;
        } else {
            for (c1 = 0, tmp = v; tmp && ((tmp & 1) == 0); tmp >>= 1)
                c1++;
        }
        sum += c1;

        /* #4, Count trailing zeros, ctz method */
        c2 = BITOPS_CTZ((unsigned int)v);
        sum += c2;
        if (c1 != c2) {
            pr_fail(c2);
            return -1;
        }
        return sum;
    }

with gcc 11.4, with `-O3` will produce

    test(unsigned int):
            test    edi, edi
            je      .L8
            mov     eax, edi
            xor     edx, edx
    .L3:
            test    al, 1
            jne     .L4
            add     edx, 1
            shr     eax
            jne     .L3
    .L4:
            rep bsf edi, edi
            lea     eax, [rdx+rdi]
            cmp     edx, edi
            jne     .L2
            ret
    .L8:
            mov     edi, 32
    .L2:
            sub     rsp, 8
            call    pr_fail(unsigned int)
            mov     eax, -1
            add     rsp, 8
            ret

where in the 0 case it will jump to `.L8`, write down the correct result in `edi` but still fall through `.L2` and report failure (as it would do if the `rep bsf` AKA `tzcnt` failed in `.L4`); the fixed code (`-O3 -DFIX`) instead produces:

    test(unsigned int):
            mov     eax, 64
            test    edi, edi
            je      .L16
            mov     eax, edi
            xor     edx, edx
    .L3:
            test    al, 1
            jne     .L4
            add     edx, 1
            shr     eax
            jne     .L3
    .L4:
            rep bsf edi, edi
            lea     eax, [rdi+rdx]
            cmp     edi, edx
            jne     .L7
            ret
    .L16:
            ret
    .L7:
            sub     rsp, 8
            call    pr_fail(unsigned int)
            mov     eax, -1
            add     rsp, 8
            ret

In this case with `v == 0` we get `eax = 64`, and then a straight jump to the `ret` in `.L16` (the result has been precomputed fully).

(godbolt link: https://gcc.godbolt.org/z/va9exb4nn )
