### PR TITLE
Makefile: fix machine detection for Ubuntu Bionic s390x VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ endif
 #
 ifneq ($(filter-out clang icc scan-build,$(COMPILER)),)
 override CFLAGS += $(foreach flag,-fipa-pta -fivopts,$(cc_supports_flag))
-ifneq ($(MACHINE),$(filter $(MACHINE),ibms390))
+ifneq ($(MACHINE),$(filter $(MACHINE),ibms390 s390))
 override CFLAGS += $(foreach flag,-fmodulo-sched,$(cc_supports_flag))
 endif
 endif


### PR DESCRIPTION
After switching to use objdump for machine type detection (7c1b860ef6), the output of `make -f Makefile.machine` on Bionic s390x VM has changed from ibms390 to s390.

Here is the complete test-machine output with objdump:
  $ objdump -D ./test-machine | grep format
  ./test-machine:     file format elf64-s390

Include this s390 type for judging if we should skip -fmodulo-sched flag. Otherwise the build will get stuck as reported in #417.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>