### PR TITLE
Fix return type of numa core dummy functions

### DIFF
--- a/core-numa.c
+++ b/core-numa.c
@@ -298,12 +298,12 @@ int stress_set_mbind(const char *arg)
 }
 
 #else
-int PURE stress_numa_nodes(void)
+unsigned long int PURE stress_numa_nodes(void)
 {
 	return 1;
 }
 
-int stress_numa_count_mem_nodes(unsigned long int *max_node)
+unsigned long int stress_numa_count_mem_nodes(unsigned long int *max_node)
 {
 	*max_node = 0;
 


### PR DESCRIPTION
It seems to me as if the type should be adapted to be consistent with the declaration in the header file. At least on one of my systems this discrepancy resulted in compile errors. If this is by design, feel free to discard this pull request :)