### PR TITLE
core-asm-ret: add lpad instruction in return code on RISC-V

### DIFF
--- a/core-asm-ret.c
+++ b/core-asm-ret.c
@@ -54,7 +54,7 @@ const stress_ret_opcode_t stress_ret_opcode =
 #elif defined(STRESS_ARCH_PPC64) && defined(STRESS_ARCH_LE)
 	{ 8, 8, "blr; nop", { 0x20, 0x00, 0x80, 0x4e, 0x00, 0x00, 0x00, 0x60 } };
 #elif defined(STRESS_ARCH_RISCV)
-	{ 2, 2, "ret", { 0x82, 0x080 } };
+	{ 8, 8, "lpad 0x0; ret", { 0x17, 0x00, 0x00, 0x00, 0x82, 0x80 } };
 #elif defined(STRESS_ARCH_S390)
 	{ 2, 2, "br %r14", { 0x07, 0xfe } };
 #elif defined(STRESS_ARCH_SH4)


### PR DESCRIPTION
Control-flow Integrity (CFI) supports Zicfiss and Zicfilp extensions that provide backward-edge and forward-edge control flow integrity respectively.

Forward-edge control flow introduces a landing pad (LPAD) instruction that must be placed at the program locations that are valid targets of indirect jumps or calls.

Without lpad instruction in return code here, some stress tests will fail due to CFI violation such as far-branch, flushcache and icache, when kernel enables the CFI config and the platform supports Zicfilp extension.

This commit adds lpad instruction with label zero, because lpad instruction does not perform the label check when the label is encoded as zero, then we don't need to set the x7 register on caller site.

The lpad instruction is encoded using the AUIPC major opcode with rd=x0, the lpad instruction executes as a no-op when Zicfilp is not active or when the extension is not implemented.

Reference:
1. Landing Pad (Zicfilp) spec: https://github.com/riscv/riscv-cfi/blob/main/src/cfi_forward.adoc#LP_INST
2. Kernel patches: https://lists.infradead.org/pipermail/linux-riscv/2025-March/067717.html