### PR TITLE
stress-prefetch: add aarch64 load prefetch instructions (prfm)

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2013-2021 Canonical, Ltd.
 # Copyright (C) 2021-2025 Colin Ian King
+# Copyright (C) 2025 SiPearl
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -1193,6 +1194,7 @@ cpufeatures: \
 	ASM_ALPHA_DRAINA \
 	ASM_ALPHA_HALT \
 	ASM_ARM_DMB_SY \
+	ASM_ARM_PRFM \
 	ASM_ARM_TLBI \
 	ASM_ARM_YIELD \
 	ASM_HPPA_DIAG \
@@ -1361,6 +1363,9 @@ ASM_ALPHA_HALT:
 
 ASM_ARM_DMB_SY:
 	$(call check,test-asm-arm-dmb-sy,HAVE_ASM_ARM_DMB_SY,ARM dmb sy instruction)
+
+ASM_ARM_PRFM:
+	$(call check,test-asm-arm-prfm,HAVE_ASM_ARM_PRFM,ARM prfm instruction)
 
 ASM_ARM_TLBI:
 	$(call check,test-asm-arm-tlbi,HAVE_ASM_ARM_TLBI,ARM tlbi instruction)

--- a/core-asm-arm.h
+++ b/core-asm-arm.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024-2025 Colin Ian King.
+ * Copyright (C) 2025 SiPearl
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -23,6 +24,40 @@
 #include "core-arch.h"
 
 #if defined(STRESS_ARCH_ARM)
+
+#if defined(HAVE_ASM_ARM_PRFM)
+/* KEEP */
+static inline void ALWAYS_INLINE stress_asm_arm_prfm_pldl1keep(void *p)
+{
+       __asm__ __volatile__("prfm PLDL1KEEP, [%0]\n" : : "r"(p) : "memory");
+}
+
+static inline void ALWAYS_INLINE stress_asm_arm_prfm_pldl2keep(void *p)
+{
+       __asm__ __volatile__("prfm PLDL2KEEP, [%0]\n" : : "r"(p) : "memory");
+}
+
+static inline void ALWAYS_INLINE stress_asm_arm_prfm_pldl3keep(void *p)
+{
+       __asm__ __volatile__("prfm PLDL3KEEP, [%0]\n" : : "r"(p) : "memory");
+}
+
+/* STRM */
+static inline void ALWAYS_INLINE stress_asm_arm_prfm_pldl1strm(void *p)
+{
+       __asm__ __volatile__("prfm PLDL1STRM, [%0]\n" : : "r"(p) : "memory");
+}
+
+static inline void ALWAYS_INLINE stress_asm_arm_prfm_pldl2strm(void *p)
+{
+       __asm__ __volatile__("prfm PLDL2STRM, [%0]\n" : : "r"(p) : "memory");
+}
+
+static inline void ALWAYS_INLINE stress_asm_arm_prfm_pldl3strm(void *p)
+{
+       __asm__ __volatile__("prfm PLDL3STRM, [%0]\n" : : "r"(p) : "memory");
+}
+#endif
 
 #if defined(HAVE_ASM_ARM_YIELD)
 static inline void ALWAYS_INLINE stress_asm_arm_yield(void)

--- a/stress-ng.1
+++ b/stress-ng.1
@@ -6354,6 +6354,36 @@ Use the x86 prefetchnta instruction (non-temporal data with respect to all
 cache levels) into a location close to the processor, minimizing cache
 pollution (x86 only).
 T}
+prfm_pldl1keep	T{
+Use the aarch64 prfm instruction with pld1keep operation (retained or temporal
+prefetch, allocated in the cache normally) to prefetch data into level 1 of the
+cache hierarchy (aarch64 only).
+T}
+prfm_pldl2keep	T{
+Use the aarch64 prfm instruction with pld1keep operation (retained or temporal
+prefetch, allocated in the cache normally) to prefetch data into level 2 of the
+cache hierarchy (aarch64 only).
+T}
+prfm_pldl3keep	T{
+Use the aarch64 prfm instruction with pld1keep operation (retained or temporal
+prefetch, allocated in the cache normally) to prefetch data into level 3 of the
+cache hierarchy (aarch64 only).
+T}
+prfm_pldl1strm	T{
+Use the aarch64 prfm instruction with pld1strm operation (streaming or
+non-temporal prefetch, for data that is used only once) to prefetch data into
+level 1 of the cache hierarchy (aarch64 only).
+T}
+prfm_pldl2strm	T{
+Use the aarch64 prfm instruction with pld1strm operation (streaming or
+non-temporal prefetch, for data that is used only once) to prefetch data into
+level 2 of the cache hierarchy (aarch64 only).
+T}
+prfm_pldl3strm	T{
+Use the aarch64 prfm instruction with pld1strm operation (streaming or
+non-temporal prefetch, for data that is used only once) to prefetch data into
+level 3 of the cache hierarchy (aarch64 only).
+T}
 .TE
 .TP
 .B \-\-prefetch\-ops N

--- a/stress-prefetch.c
+++ b/stress-prefetch.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2021 Canonical, Ltd.
  * Copyright (C) 2022-2025 Colin Ian King.
+ * Copyright (C) 2025 SiPearl
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -18,6 +19,7 @@
  *
  */
 #include "stress-ng.h"
+#include "core-asm-arm.h"
 #include "core-asm-ppc64.h"
 #include "core-asm-x86.h"
 #include "core-builtin.h"
@@ -57,15 +59,21 @@ typedef struct {
 	bool check_prefetch_rate;
 } stress_prefetch_method_t;
 
-#define STRESS_PREFETCH_BUILTIN		(0)
-#define STRESS_PREFETCH_BUILTIN_L0	(1)
-#define STRESS_PREFETCH_BUILTIN_L3	(2)
-#define STRESS_PREFETCH_X86_PREFETCHT0	(3)
-#define STRESS_PREFETCH_X86_PREFETCHT1	(4)
-#define STRESS_PREFETCH_X86_PREFETCHT2	(5)
-#define STRESS_PREFETCH_X86_PREFETCHNTA	(6)
-#define STRESS_PREFETCH_PPC64_DCBT	(7)
-#define STRESS_PREFETCH_PPC64_DCBTST	(8)
+#define STRESS_PREFETCH_BUILTIN            (0)
+#define STRESS_PREFETCH_BUILTIN_L0         (1)
+#define STRESS_PREFETCH_BUILTIN_L3         (2)
+#define STRESS_PREFETCH_X86_PREFETCHT0     (3)
+#define STRESS_PREFETCH_X86_PREFETCHT1     (4)
+#define STRESS_PREFETCH_X86_PREFETCHT2     (5)
+#define STRESS_PREFETCH_X86_PREFETCHNTA    (6)
+#define STRESS_PREFETCH_PPC64_DCBT         (7)
+#define STRESS_PREFETCH_PPC64_DCBTST       (8)
+#define STRESS_PREFETCH_ARM_PRFM_PLDL1KEEP (9)
+#define STRESS_PREFETCH_ARM_PRFM_PLDL2KEEP (10)
+#define STRESS_PREFETCH_ARM_PRFM_PLDL3KEEP (11)
+#define STRESS_PREFETCH_ARM_PRFM_PLDL1STRM (12)
+#define STRESS_PREFETCH_ARM_PRFM_PLDL2STRM (13)
+#define STRESS_PREFETCH_ARM_PRFM_PLDL3STRM (14)
 
 static inline bool stress_prefetch_true(void)
 {
@@ -93,6 +101,14 @@ stress_prefetch_method_t prefetch_methods[] = {
 #endif
 #if defined(HAVE_ASM_PPC64_DCBTST)
 	{ "dcbtst",		STRESS_PREFETCH_PPC64_DCBTST,	stress_prefetch_true,	true },
+#endif
+#if defined(HAVE_ASM_ARM_PRFM)
+	{ "prfm_pldl1keep",	STRESS_PREFETCH_ARM_PRFM_PLDL1KEEP,	stress_prefetch_true,	true },
+	{ "prfm_pldl2keep",	STRESS_PREFETCH_ARM_PRFM_PLDL2KEEP,	stress_prefetch_true,	true },
+	{ "prfm_pldl3keep",	STRESS_PREFETCH_ARM_PRFM_PLDL3KEEP,	stress_prefetch_true,	true },
+	{ "prfm_pldl1strm",	STRESS_PREFETCH_ARM_PRFM_PLDL1STRM,	stress_prefetch_true,	true },
+	{ "prfm_pldl2strm",	STRESS_PREFETCH_ARM_PRFM_PLDL2STRM,	stress_prefetch_true,	true },
+	{ "prfm_pldl3strm",	STRESS_PREFETCH_ARM_PRFM_PLDL3STRM,	stress_prefetch_true,	true },
 #endif
 };
 
@@ -284,6 +300,26 @@ static inline void OPTIMIZE3 stress_prefetch_benchmark(
 #if defined(HAVE_ASM_PPC64_DCBTST)
 		case STRESS_PREFETCH_PPC64_DCBTST:
 			STRESS_PREFETCH_LOOP(stress_asm_ppc64_dcbtst, "ppc64 dcbtst");
+			break;
+#endif
+#if defined(HAVE_ASM_ARM_PRFM)
+		case STRESS_PREFETCH_ARM_PRFM_PLDL1KEEP:
+			STRESS_PREFETCH_LOOP(stress_asm_arm_prfm_pldl1keep, "arm prfm pldl1keep");
+			break;
+		case STRESS_PREFETCH_ARM_PRFM_PLDL2KEEP:
+			STRESS_PREFETCH_LOOP(stress_asm_arm_prfm_pldl2keep, "arm prfm pldl2keep");
+			break;
+		case STRESS_PREFETCH_ARM_PRFM_PLDL3KEEP:
+			STRESS_PREFETCH_LOOP(stress_asm_arm_prfm_pldl3keep, "arm prfm pldl3keep");
+			break;
+		case STRESS_PREFETCH_ARM_PRFM_PLDL1STRM:
+			STRESS_PREFETCH_LOOP(stress_asm_arm_prfm_pldl1strm, "arm prfm pldl1strm");
+			break;
+		case STRESS_PREFETCH_ARM_PRFM_PLDL2STRM:
+			STRESS_PREFETCH_LOOP(stress_asm_arm_prfm_pldl2strm, "arm prfm pldl2strm");
+			break;
+		case STRESS_PREFETCH_ARM_PRFM_PLDL3STRM:
+			STRESS_PREFETCH_LOOP(stress_asm_arm_prfm_pldl3strm, "arm prfm pldl3strm");
 			break;
 #endif
 		}

--- a/test/test-asm-arm-prfm.c
+++ b/test/test-asm-arm-prfm.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 SiPearl
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+#if defined(__ARM_ARCH_8A__) || defined(__aarch64__)
+int main(void)
+{
+    int a = 0;
+    __asm__ __volatile__("prfm PLDL1KEEP, [%0]\n" : : "r" (&a) : "memory", "cc");
+
+    return 0;
+}
+#else
+#error not an ARMv8 so no prfm instruction
+#endif


### PR DESCRIPTION
The prefetch stressor doesn't support some load prfm instructions because prefetch builtins don't generate them all.

This commit therefore adds explicit support for all load prfm instructions. Store prfm instructions have not been added, as the kernel only uses load instructions.

* Makefile.config,
core-asm-arm.h,
stress-prefetch.c,
test/test-asm-arm-prfm.c: Here.