### PR TITLE
core-config-check: Fix segfault caused by uninitialized namelist

### DIFF
--- a/core-config-check.c
+++ b/core-config-check.c
@@ -107,7 +107,7 @@ void stress_config_check(void)
 		static const char cpu_path[] = "/sys/devices/system/cpu";
 		static const char boost_path[] = "/sys/devices/system/cpu/cpufreq/boost";
 		uint64_t value;
-		struct dirent **namelist;
+		struct dirent **namelist = NULL;
 		int n, i;
 		int powersave = 0;
 


### PR DESCRIPTION
On L136
```c
n = scandir(cpu_path, &namelist, stress_config_check_cpu_filter, alphasort);
```
if the directory `/sys/devices/system/cpu` does not exist (sysfs is not mounted or likewise), we get `n = -1`, skipping the next for loop and call into `stress_dirent_list_free()`.
At this point `dlist` is **uninitialized** because `scandir()` failed and did not allocate a space for it, thus `free(dlist)` has a chance to raise a segfault if `dlist` is not zero
```c
void stress_dirent_list_free(struct dirent **dlist, const int n)
{
	if (LIKELY(dlist != NULL)) {
		int i;

		for (i = 0; i < n; i++) {
			if (dlist[i])
				free(dlist[i]);
		}
		free(dlist);
	}
}
```
