### PR TITLE
core-helper: prevent loss of terminating signals due to siglongjmp

### DIFF
--- a/core-helper.h
+++ b/core-helper.h
@@ -122,6 +122,7 @@ extern WARN_UNUSED int stress_get_bad_fd(void);
 extern WARN_UNUSED int stress_sigaltstack_no_check(void *stack, const size_t size);
 extern WARN_UNUSED int stress_sigaltstack(void *stack, const size_t size);
 extern void stress_sigaltstack_disable(void);
+extern void stress_mask_longjump_signals(sigset_t *set);
 extern WARN_UNUSED int stress_sighandler(const char *name, const int signum,
 	void (*handler)(int), struct sigaction *orig_action);
 extern WARN_UNUSED int stress_sigchld_set_handler(stress_args_t *args);

--- a/stress-ng.c
+++ b/stress-ng.c
@@ -727,6 +727,12 @@ static int stress_set_handler(const char *stress, const bool child)
 #endif
 #if defined(SA_SIGINFO)
 	(void)shim_memset(&sa, 0, sizeof(sa));
+	(void)sigemptyset(&sa.sa_mask);
+	/*
+	 *  Signals intended to stop stress-ng should never be interrupted
+	 *  by a signal with a handler which may not return to the caller.
+	 */
+	stress_mask_longjump_signals(&sa.sa_mask);
 	sa.sa_sigaction = stress_sigalrm_action_handler;
 	sa.sa_flags = SA_SIGINFO;
 	if (sigaction(SIGALRM, &sa, NULL) < 0) {


### PR DESCRIPTION
The fix which closed #529 does not really fix the issue. I don't have permission to reopen the issue. Here is a proposed fix instead.