### PR TITLE
stress-cpu: introduce matrixprod64 benchmark

### DIFF
--- a/stress-ng.1
+++ b/stress-ng.1
@@ -1893,10 +1893,16 @@ loop	T{
 simple empty loop.
 T}
 matrixprod	T{
-matrix product of two 128 \(mu 128 matrices of double floats. Testing on 64
+matrix product of two 128 \(mu 128 matrices of long double floats. Testing on 64
 bit x86 hardware shows that this is provides a good mix of memory, cache and
 floating point operations and is probably the best CPU method to use to make
-a CPU run hot.
+a CPU run hot, relying of x87 80-bits extended precision float arithmetic.
+T}
+matrixprod64	T{
+matrix product of two 256 \(mu 256 matrices of double floats. Testing on 64
+bit hardware shows that this is provides a good mix of memory, cache and
+floating point operations and is probably the best CPU method to use to make
+a CPU run hot, with fp64 arithmetic.
 T}
 nsqrt	T{
 compute sqrt() of long doubles using Newton-Raphson.


### PR DESCRIPTION
This PR is mostly an RFC; feel free to modify if needed; the primary goal is to make the matrixprod benchmark more portable.

This benchmark is a copy-paste of the matrixprod benchmark, but made to be less dependent on the x87 instruction set, and use standard 64-bits floats instead.

On arm64 (for example), matrixprod gives very bad performance because of the 80-bits float emulation.

The ratio was computed between matrixprod and matrixprod64 on an Intel Core i7-10850H.

matrixprod64 should also use double the data cache because of the matrices sizes going from 128x128 (80-bits, but aligned to 16 bytes, so 256KiB) to 256x256 (64-bits, so 512KiB).