### PR TITLE
core-target-clones: add arch=znver[1-5]

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1337,6 +1337,11 @@ cpufeatures: \
 	TARGET_CLONES_SSE4_2 \
 	TARGET_CLONES_SSSE3 \
 	TARGET_CLONES_TIGERLAKE \
+	TARGET_CLONES_ZNVER1 \
+	TARGET_CLONES_ZNVER2 \
+	TARGET_CLONES_ZNVER3 \
+	TARGET_CLONES_ZNVER4 \
+	TARGET_CLONES_ZNVER5 \
 	VLA_ARG \
 	VECMATH
 
@@ -1744,6 +1749,21 @@ TARGET_CLONES_LUNARLAKE:
 
 TARGET_CLONES_PANTHERLAKE:
 	$(call check,test-target-clones,HAVE_TARGET_CLONES_PANTHERLAKE,target_clones arch=pantherlake attribute (x86),,,'"default$(comma)arch=pantherlake"')
+
+TARGET_CLONES_ZNVER1:
+	$(call check,test-target-clones,HAVE_TARGET_CLONES_ZNVER1,target_clones arch=znver1 attribute (x86),,,'"default$(comma)arch=znver1"')
+
+TARGET_CLONES_ZNVER2:
+	$(call check,test-target-clones,HAVE_TARGET_CLONES_ZNVER2,target_clones arch=znver2 attribute (x86),,,'"default$(comma)arch=znver2"')
+
+TARGET_CLONES_ZNVER3:
+	$(call check,test-target-clones,HAVE_TARGET_CLONES_ZNVER3,target_clones arch=znver3 attribute (x86),,,'"default$(comma)arch=znver3"')
+
+TARGET_CLONES_ZNVER4:
+	$(call check,test-target-clones,HAVE_TARGET_CLONES_ZNVER4,target_clones arch=znver4 attribute (x86),,,'"default$(comma)arch=znver4"')
+
+TARGET_CLONES_ZNVER5:
+	$(call check,test-target-clones,HAVE_TARGET_CLONES_ZNVER5,target_clones arch=znver5 attribute (x86),,,'"default$(comma)arch=znver5"')
 
 TARGET_CLONES_POWER9:
 	$(call check,test-target-clones,HAVE_TARGET_CLONES_POWER9,target_clones cpu=power attribute (power9),,,'"default$(comma)cpu=power9"')

--- a/core-target-clones.h
+++ b/core-target-clones.h
@@ -174,6 +174,46 @@
 #define TARGET_CLONE_LUNARLAKE
 #endif
 
+#if defined(HAVE_TARGET_CLONES_ZNVER1) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_ZNVER1 "arch=znver1",
+#define TARGET_CLONE_USE
+#else
+#define TARGET_CLONE_ZNVER1
+#endif
+
+#if defined(HAVE_TARGET_CLONES_ZNVER2) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_ZNVER2 "arch=znver2",
+#define TARGET_CLONE_USE
+#else
+#define TARGET_CLONE_ZNVER2
+#endif
+
+#if defined(HAVE_TARGET_CLONES_ZNVER3) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_ZNVER3 "arch=znver3",
+#define TARGET_CLONE_USE
+#else
+#define TARGET_CLONE_ZNVER3
+#endif
+
+#if defined(HAVE_TARGET_CLONES_ZNVER4) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_ZNVER4 "arch=znver4",
+#define TARGET_CLONE_USE
+#else
+#define TARGET_CLONE_ZNVER4
+#endif
+
+#if defined(HAVE_TARGET_CLONES_ZNVER5) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_ZNVER5 "arch=znver5",
+#define TARGET_CLONE_USE
+#else
+#define TARGET_CLONE_ZNVER5
+#endif
+
 #define TARGET_CLONES_ALL		\
 	TARGET_CLONE_AVX		\
 	TARGET_CLONE_AVX2 		\
@@ -195,6 +235,11 @@
 	TARGET_CLONE_LUNARLAKE		\
 	TARGET_CLONE_PANTHERLAKE	\
 	TARGET_CLONE_DIAMONDRAPIDS	\
+	TARGET_CLONE_ZNVER1		\
+	TARGET_CLONE_ZNVER2		\
+	TARGET_CLONE_ZNVER3		\
+	TARGET_CLONE_ZNVER4		\
+	TARGET_CLONE_ZNVER5		\
 	"default"
 
 #if defined(TARGET_CLONE_USE)


### PR DESCRIPTION
On a zen4 CPU, this shows a 28% perf difference on VNNI tests (vs the avx2 target clone), but is almost invisible most of the time.