### PR TITLE
Makefile.machine: use OBJDUMP when available

### DIFF
--- a/Makefile.machine
+++ b/Makefile.machine
@@ -16,10 +16,12 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 #
 
+OBJDUMP ?= objdump
+
 all:
 	@if objdump -H > /dev/null 2>&1 ; then \
 		$(CC) test/test-machine.c -o test-machine > /dev/null 2>&1 && \
-			objdump -D ./test-machine | grep format | awk '{print $$4}' \
+			$(OBJDUMP) -D ./test-machine | grep format | awk '{print $$4}' \
 			| sed 's/elf[0-9\-]*//' | sed 's/[\-]*linux//' || echo "unknown"; \
 		rm -f test-machine; \
 	else \


### PR DESCRIPTION
Hi @ColinIanKing,

When cross-compiling, CC is defined as the cross-C compiler. However, in Makefile.machine, we use the host `objdump`, resulting in the error:
```
objdump: can't disassemble for architecture UNKNOWN!
```
This commit introduces the use of `OBJDUMP`, with a default value to `objdump`. This allows defining `OBJDUMP` as `objdump` from the toolchain (as done for example in Buildroot).

If you prefer this as a patch over email, please feel free to ask.

Thank you.