### PR TITLE
stress-rseq: use either linux/rseq.h or sys/rseq.h, not both

### DIFF
--- a/stress-rseq.c
+++ b/stress-rseq.c
@@ -25,11 +25,12 @@
 #include "core-pragma.h"
 
 #if defined(HAVE_LINUX_RSEQ_H)
-#include <linux/rseq.h>
-#endif
-#if defined(HAVE_SYS_RSEQ_H)
-#include <sys/rseq.h>
-#endif
+#  include <linux/rseq.h>
+#else /* HAVE_LINUX_RSEQ_H undefined */
+#  if defined(HAVE_SYS_RSEQ_H)
+#    include <sys/rseq.h>
+#  endif /* HAVE_SYS_RSEQ_H undefined */
+#endif /* HAVE_LINUX_RSEQ_H undefined */
 
 static const stress_help_t help[] = {
 	{ NULL,	"rseq N",	"start N workers that exercise restartable sequences" },


### PR DESCRIPTION
Hi @ColinIanKing,

If both HAVE_LINUX_RSEQ_H and HAVE_SYS_RSEQ_H are defined, we end up including both headers, causing redeclaration errors on the rseq header definitions.
This commit changes the logic to include the Linux version only if available, and the sys version otherwise, instead of both.

If you prefer this as a patch over email, please feel free to ask.

Thank you.