### PR TITLE
Fix typo 'checkboard' -> 'checkerboard' in stress-ng.1

### DIFF
--- a/stress-ng.1
+++ b/stress-ng.1
@@ -9604,7 +9604,7 @@ cache\-stripe	T{
 work through memory in 64 byte cache sized chunks, writing in ascending
 address order on even offsets and descending address order on odd offsets.
 T}
-checkboard	T{
+checkerboard	T{
 work through memory writing alternative zero/one bit values into memory
 in a mixed checkerboard pattern. Memory is swapped around to ensure every
 bit is read, bit flipped and re-written and then re-read for verification.


### PR DESCRIPTION
Stressor `vm-method` doesn't have a `checkboard` method, but does have a `checkerboard` method. This fixes the manpage to reflect the correct spelling.