### PR TITLE
Fix build for QNX 8

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -59,12 +59,15 @@ LIB_NETWORK := -lnetwork
 LIB_SOCKET := -lsocket
 LIB_NSL := -lnsl
 LIB_LZMA := -llzma
+ifeq ($(findstring nto-qnx8,$(CC)),nto-qnx8)
+LIB_FSNOTIFY := -lfsnotify
+endif
 
 LIB_ORDER := $(LIB_ACL) $(LIB_AIO) $(LIB_APPARMOR) $(LIB_ATOMIC) $(LIB_BSD) \
 	$(LIB_CRYPT) $(LIB_DL) $(LIB_IPSEC_MB) $(LIB_JPEG) $(LIB_JUDY) \
 	$(LIB_KMOD) $(LIB_EGL) $(LIB_GLES2) $(LIB_MPFR) $(LIB_GMP) $(LIB_GBM) $(LIB_MD) \
 	$(LIB_SCTP) $(LIB_XXHASH) $(LIB_Z) $(LIB_RT) \
-	$(LIB_PTHREAD) $(LIB_MATH) $(LIB_NETWORK) $(LIB_SOCKET) $(LIB_NSL) $(LIB_LZMA) $(LIB_C)
+	$(LIB_PTHREAD) $(LIB_MATH) $(LIB_NETWORK) $(LIB_SOCKET) $(LIB_FSNOTIFY) $(LIB_NSL) $(LIB_LZMA) $(LIB_C)
 
 ifeq ($(shell $(CC) -v 2>&1 | grep 'gcc version' | grep -v 'icc' | wc -l),1)
 ifeq ($(shell $(CC) -v 2>&1 | grep 'musl-gcc' | wc -l),0)
@@ -101,6 +104,11 @@ endif
 ifeq ($(findstring nto-qnx,$(CC)),nto-qnx)
 	CONFIG_LDFLAGS += $(LIB_SOCKET)
 endif
+
+ifeq ($(findstring nto-qnx8,$(CC)),nto-qnx8)
+	CONFIG_LDFLAGS += $(LIB_FSNOTIFY)
+endif
+
 #
 #  This must always come after -pthread so that static linking works
 #

--- a/README.md
+++ b/README.md
@@ -196,11 +196,18 @@ the toolchain (both CC and CXX). For example, a mips64 cross build:
     STATIC=1 CC=mips64-linux-gnuabi64-gcc CXX=mips64-linux-gnuabi64-g++ make -j $(nproc)
 ```
 
-To perform a cross-compile for qnx, for example, a aarch64 qnx cross build:
+To perform a cross-compilation for QNX 7.1, for example, an aarch64 QNX cross build:
 
 ```
     make clean
     CC=aarch64-unknown-nto-qnx7.1.0-gcc CXX=aarch64-unknown-nto-qnx7.1.0-g++ STATIC=1 make
+```
+
+To perform a cross-compilation for QNX 8, for example, an aarch64 QNX cross build:
+
+```
+    make clean
+    CC=aarch64-unknown-nto-qnx8.0.0-gcc CXX=aarch64-unknown-nto-qnx8.0.0-g++ make
 ```
 
 To generate a PDF version of the manual (requires ps2pdf to be installed)

--- a/stress-ng.h
+++ b/stress-ng.h
@@ -174,6 +174,18 @@
 #endif
 #endif
 
+#if defined(HAVE_SYS_TREE_H)
+#if defined(__QNX__) && __QNX__ >= 800
+/* QNX 8 contains a version of sys/tree.h which uses __uintptr_t and __unused */
+#ifndef __uintptr_t
+#define __uintptr_t uintptr_t
+#endif
+#ifndef __unused
+#define __unused
+#endif
+#endif
+#endif
+
 /*
  *  Per stressor misc rate metrics
  */


### PR DESCRIPTION
Relevant changes between QNX 7.1 and QNX 8:
- sys/tree.h changed to an older NetBSD version that requires __uintptr_t and __unused
-> we got compilation errors in stress-mmaprandom.c, stress-sparsematrix.c and stress-tree.c
- there is no longer a libsocket.a static library, so we must link against the libsocket.so shared library
- The inotify_* functions (e.g., inotify_add_watch(), inotify_init()) have moved from libc to a new library, libfsnotify.so (not provided as a static library)
 -> therefore we can't use STATIC=1 with QNX 8

I verified the build for the following platforms:
- QNX 7.1 aarch64
- QNX 8 aarch64
- Ubuntu 24.04 x86_64

If you want to get a free QNX 8 compiler, try https://www.qnx.com/products/everywhere/