### PR TITLE
stress-*: preserve LD_LIBRARY_PATH in all exec() calls (#587)

### DIFF
--- a/core-helper.c
+++ b/core-helper.c
@@ -1985,3 +1985,21 @@ void stress_no_return(void)
 {
 	_exit(EXIT_FAILURE);
 }
+
+char *stress_get_env_ld_library_path()
+{
+	char *ld_library_path = NULL;
+	char *parent_ld_path;
+	/*
+	 * Determine if ld_library_path is set and must be preserved to self-launch
+	 */
+	parent_ld_path = getenv("LD_LIBRARY_PATH");
+	if (parent_ld_path) {
+		ld_library_path = malloc(strlen(parent_ld_path) + 17);
+		if (ld_library_path) {
+			(void) snprintf(ld_library_path, strlen(parent_ld_path) + 17, "LD_LIBRARY_PATH=%s", parent_ld_path);
+		}
+	}
+	return ld_library_path;
+}
+

--- a/core-helper.h
+++ b/core-helper.h
@@ -89,5 +89,6 @@ extern uint64_t stress_get_machine_id(void);
 extern void stress_zero_metrics(stress_metrics_t *metrics, const size_t n);
 extern bool OPTIMIZE3 stress_data_is_not_zero(uint64_t *buffer, const size_t len);
 extern void stress_no_return(void) NORETURN;
+extern WARN_UNUSED char *stress_get_env_ld_library_path();
 
 #endif

--- a/stress-cpu-sched.c
+++ b/stress-cpu-sched.c
@@ -627,6 +627,7 @@ again:
 		const pid_t mypid = getpid();
 
 		stress_set_proc_state(args->name, STRESS_STATE_RUN);
+
 #if defined(HAVE_TIMER_CLOCK_REALTIME)
 		if (timerid != (timer_t)-1) {
 			(void)timer_delete(timerid);
@@ -643,7 +644,7 @@ again:
 		argv[2] = NULL;
 		argv[3] = NULL;
 
-		env[0] = NULL;
+		env[0] = stress_get_env_ld_library_path();
 		env[1] = NULL;
 
 		_exit(execve(exec_prog, argv, env));

--- a/stress-exec.c
+++ b/stress-exec.c
@@ -672,6 +672,7 @@ static int stress_exec(stress_args_t *args)
 	char *exec_prog;
 	char exec_path[PATH_MAX];
 	char garbage_prog[PATH_MAX];
+	char *ld_library_path = NULL;
 	int ret, rc = EXIT_FAILURE;
 #if (defined(HAVE_EXECVEAT) ||	\
      defined(HAVE_FEXECVE)) &&	\
@@ -701,6 +702,8 @@ static int stress_exec(stress_args_t *args)
 		exec_fork_method = stress_exec_fork_methods[exec_fork_method_idx].method;
 
 	stress_ksm_memory_merge(1);
+
+	ld_library_path = stress_get_env_ld_library_path();
 
 	/*
 	 *  Determine our own self as the executable, e.g. run stress-ng
@@ -831,7 +834,7 @@ static int stress_exec(stress_args_t *args)
 			sph->arg.argv[1] = "--exec-exit";
 			sph->arg.argv[2] = NULL;
 			sph->arg.argv[3] = NULL;
-			sph->arg.env[0] = NULL;
+			sph->arg.env[0] = ld_library_path;
 			sph->arg.env[1] = NULL;
 
 			switch (exec_fork_method) {
@@ -940,6 +943,8 @@ static int stress_exec(stress_args_t *args)
 
 	stress_set_proc_state(args->name, STRESS_STATE_DEINIT);
 
+	if (ld_library_path)
+		free(ld_library_path);
 
 #if (defined(HAVE_EXECVEAT) ||	\
      defined(HAVE_FEXECVE)) &&	\

--- a/stress-spawn.c
+++ b/stress-spawn.c
@@ -62,7 +62,6 @@ static int stress_spawn(stress_args_t *args)
 	char *path;
 	char exec_path[PATH_MAX];
 	char *ld_library_path = NULL;
-	char *parent_ld_path;
 	uint64_t spawn_fails = 0, spawn_calls = 0;
 	static char *argv_new[] = { NULL, "--exec-exit", NULL };
 	static char *env_new[] = { NULL, NULL };
@@ -77,17 +76,8 @@ static int stress_spawn(stress_args_t *args)
 		return EXIT_FAILURE;
 	}
 
-	/*
-	 * Determine if ld_library_path is set and must be preserved to self-launch
-	 */
-	parent_ld_path = getenv("LD_LIBRARY_PATH");
-	if (parent_ld_path) {
-		ld_library_path = malloc(strlen(parent_ld_path) + 16);
-		if (ld_library_path) {
-			(void)snprintf(ld_library_path, strlen(parent_ld_path) + 16, "LD_LIBRARY_PATH=%s", parent_ld_path);
-			env_new[0] = ld_library_path;
-		}
-	}
+	ld_library_path = stress_get_env_ld_library_path();
+	env_new[0] = ld_library_path;
 
 	/*
 	 *  Determine our own self as the executable, e.g. run stress-ng

--- a/stress-syscall.c
+++ b/stress-syscall.c
@@ -1602,12 +1602,13 @@ static int syscall_execve(void)
 	else if (pid == 0) {
 		int ret;
 		char *argv[3];
-		char *env[1];
+		char *env[2];
 
 		argv[0] = syscall_exec_prog;
 		argv[1] = "--exec-exit";
 		argv[2] = NULL;
-		env[0] = NULL;
+		env[0] = stress_get_env_ld_library_path();
+		env[1] = NULL;
 
 		syscall_execve_silence_stdio();
 
@@ -1647,7 +1648,7 @@ static int syscall_execveat(void)
 		int fd;
 #endif
 		char *argv[3];
-		char *env[1];
+		char *env[2];
 
 #if defined(O_PATH) &&	\
     defined(AT_EMPTY_PATH)
@@ -1656,7 +1657,8 @@ static int syscall_execveat(void)
 		argv[0] = syscall_exec_prog;
 		argv[1] = "--exec-exit";
 		argv[2] = NULL;
-		env[0] = NULL;
+		env[0] = stress_get_env_ld_library_path();
+		env[1] = NULL;
 
 		syscall_execve_silence_stdio();
 


### PR DESCRIPTION
Fix all tests that do execve/spawn to forward the LD_LIBRARY_PATH environment variable to prevent issues when stress-ng is shipped in a folder with its dependencies.

fix #587