### PR TITLE
Fix: failure to cross build to s390x due to fmodulo-sched in Debian

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,9 @@
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 DPKG_EXPORT_BUILDFLAGS = 1
+DPKG_EXPORT_BUILDTOOLS = 1
 include /usr/share/dpkg/buildflags.mk
+include /usr/share/dpkg/buildtools.mk
 
 override_dh_auto_build:
 	$(shell dpkg-buildflags --export=sh); dh_auto_build -- $(if $(filter terse,$(DEB_BUILD_OPTIONS)),,VERBOSE=1)


### PR DESCRIPTION
Closes [bug 1120809](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1120809) in Debian.
error log: [https://crossqa.debian.net/build/stress-ng_0.19.06-3_s390x_20251115213510.log](https://crossqa.debian.net/build/stress-ng_0.19.06-3_s390x_20251115213510.log)

When doing the cross compilation, although the CC and CXX variables was set to the target architecture's toolchain, it was using the native objdump. So, `Makefile.machine`, instead of generating the output `s390`, was generating `big` which caused the if condition in the Makefile to fail and led to the addition of `-fmodulo-sched` flag to `CC` which resulted in the insane build time.

`/usr/share/dpkg/buildtools.mk` sets all the necessary variables including CC, CXX and OBJDUMP accordingly and hence exporting it fixes the issue.