### PR TITLE
stress-pthread: fix non-NPTL build

### DIFF
--- a/stress-pthread.c
+++ b/stress-pthread.c
@@ -564,7 +564,11 @@ static int stress_pthread(stress_args_t *args)
 
 			pthreads[i].t_create = stress_time_now();
 			pthreads[i].t_run = pthreads[i].t_create;
+#if defined(HAVE_PTHREAD_ATTR_SETSTACK)
 			pthreads[i].ret = pthread_create(&pthreads[i].pthread, &attr,
+#else
+			pthreads[i].ret = pthread_create(&pthreads[i].pthread, NULL,
+#endif
 				stress_pthread_func, (void *)&pargs);
 			if (UNLIKELY(pthreads[i].ret)) {
 				/* Out of resources, don't try any more */


### PR DESCRIPTION
https://github.com/ColinIanKing/stress-ng/commit/15b26e33daaf36acd5eeceaaf6fc954f46792a8b added the usage of attr without using HAVE_PTHREAD_ATTR_SETSTACK for toolchains without NPTL support.

This patch fixes build errors detected by buildroot autobuilders:
https://autobuild.buildroot.net/results/d4f/d4fadef213455b1776d93e30e51ffe09fb1879c5/build-end.log
```
stress-pthread.c: In function 'stress_pthread':
stress-pthread.c:567:81: error: 'attr' undeclared (first use in this function)
  567 |                         pthreads[i].ret = pthread_create(&pthreads[i].pthread, &attr,
```