### PR TITLE
stress-peterson: fix race condition for weak memory model archs.

### DIFF
--- a/stress-peterson.c
+++ b/stress-peterson.c
@@ -125,11 +125,15 @@ static int stress_peterson_p0(stress_args_t *args)
 #endif
 	}
 
+#if defined(STRESS_ARCH_ARM) || defined(STRESS_ARCH_PPC64) || defined(STRESS_ARCH_PPC) || defined(STRESS_ARCH_RISCV)
+	peterson_mfence();
+	peterson_mbarrier();
+#endif
 	/* Critical section */
 	check0 = peterson->m.check;
 	peterson->m.check++;
 	check1 = peterson->m.check;
-#if defined(STRESS_ARCH_ARM)
+#if defined(STRESS_ARCH_ARM) || defined(STRESS_ARCH_PPC64) || defined(STRESS_ARCH_PPC) || defined(STRESS_ARCH_RISCV)
 	peterson_mfence();
 	peterson_mbarrier();
 #endif
@@ -164,11 +168,15 @@ static int stress_peterson_p1(stress_args_t *args)
 #endif
 	}
 
+#if defined(STRESS_ARCH_ARM) || defined(STRESS_ARCH_PPC64) || defined(STRESS_ARCH_PPC) || defined(STRESS_ARCH_RISCV)
+	peterson_mfence();
+	peterson_mbarrier();
+#endif
 	/* Critical section */
 	check0 = peterson->m.check;
 	peterson->m.check--;
 	check1 = peterson->m.check;
-#if defined(STRESS_ARCH_ARM)
+#if defined(STRESS_ARCH_ARM) || defined(STRESS_ARCH_PPC64) || defined(STRESS_ARCH_PPC) || defined(STRESS_ARCH_RISCV)
 	peterson_mfence();
 	peterson_mbarrier();
 #endif


### PR DESCRIPTION
Added memory barrier before the critical section (1) and extended the memory barrier after the critical section to riscv and powerpc architectures (2).

We need (1) because cpu can reoder these critical section before the while loop because there is no dependency between while loop control variables and critical section variables. Additionally, embedding the critical section into an if statement like the following also works (because it creates dependency):
```
  // stress_peterson_p0()
  if (!peterson->m.flag[1])
  {
    /* Critical section */
    check0 = peterson->m.check;
    peterson->m.check++;
    check1 = peterson->m.check;
  }
```
We need (2) because all these architectures have week memory models. Comparatively, between powerpc(32/64), riscv, and arm, arm has the strongest memory model. So, anything required by arm is also required by the other 2.