### PR TITLE
resources: add options to control stressor load

### DIFF
--- a/core-opts.c
+++ b/core-opts.c
@@ -908,6 +908,8 @@ const struct option stress_long_options[] = {
 	{ "resctrl",		1,	0,	OPT_resctrl },
 	{ "resources",		1,	0,	OPT_resources },
 	{ "resources-mlock",	0,	0,	OPT_resources_mlock },
+	{ "resources-share",	0,	0,	OPT_resources_share },
+	{ "resources-num",	1,	0,	OPT_resources_num },
 	{ "resources-ops",	1,	0,	OPT_resources_ops },
 	{ "revio",		1,	0,	OPT_revio },
 	{ "revio-bytes",	1,	0,	OPT_revio_bytes },

--- a/core-opts.h
+++ b/core-opts.h
@@ -1286,8 +1286,10 @@ typedef enum {
 	OPT_resctrl,
 
 	OPT_resources,
-	OPT_resources_mlock,
 	OPT_resources_ops,
+	OPT_resources_num,
+	OPT_resources_share,
+	OPT_resources_mlock,
 
 	OPT_revio,
 	OPT_revio_ops,


### PR DESCRIPTION
By default stressor 'resources' is quite demanding, forking 2048 children and allocating 2048 resource instances, multiplied by the number of started instances. Add stressor-specific command line options to tune the load:

- 'resources-num' to specify the number of resources instances
- 'resources-share' to share specified number of resources between cpus

To maintain backward compatibility, the default values preserve the previous behavior.