### PR TITLE
resources: revert exit procedure

### DIFF
--- a/stress-resources.c
+++ b/stress-resources.c
@@ -43,8 +43,6 @@ static const stress_help_t help[] = {
 	{ NULL,	NULL,                NULL }
 };
 
-static pid_t stress_reources_pid = -1;
-
 /*
  *  stress_resources()
  *	stress by forking and exiting
@@ -58,8 +56,6 @@ static int stress_resources(stress_args_t *args)
 	stress_resources_t *resources;
 	stress_pid_t *s_pids;
 	bool resources_mlock = false;
-
-	stress_reources_pid = getpid();
 
 	if (!stress_get_setting("resources-mlock", &resources_mlock)) {
 		if (g_opt_flags & OPT_FLAGS_AGGRESSIVE)
@@ -157,12 +153,9 @@ static int stress_resources(stress_args_t *args)
 				break;
 			stress_bogo_inc(args);
 		}
-		for (i = 0; i < resources_procs; i++) {
-			const pid_t pid = s_pids[i].pid;
 
-			if ((pid > 1) && (pid != stress_reources_pid))
-				stress_wait_until_reaped(args, pid, SIGALRM, true);
-		}
+		stress_kill_and_wait_many(args, s_pids, resources_procs, SIGALRM, true);
+
 	} while (stress_continue(args));
 
 	stress_set_proc_state(args->name, STRESS_STATE_DEINIT);


### PR DESCRIPTION
In addition to the new option `--resources-proc` the commit 1b92d4f3ac5630501c3254af3f70a87f3ab073ee also modified exit  path replacing `stress_kill_and_wait_many` with `stress_wait_until_reaped` cycle. This new exit path implementation seems to be less reliable, probably because it does not send an additional signals prior to waiting for a child process. 

I could reproduce unexpectedly long delays on exit not only on slow target DUTs, but also on my x86 host, see further examples. 

Current behavior on master branch w/o the change from this MR:

```
$ time ./stress-ng --resources 0 --resources-procs 4095 --resources-num 4095 --timeout 10          
stress-ng: info:  [3589130] setting to a 10 secs run per stressor
stress-ng: info:  [3589130] dispatching hogs: 12 resources
stress-ng: info:  [3589131] resources: using 4095 resources and spawning 4095 child processes per instance

stress-ng: info:  [3589130] skipped: 0
stress-ng: info:  [3589130] passed: 12: resources (12)
stress-ng: info:  [3589130] failed: 0
stress-ng: info:  [3589130] metrics untrustworthy: 0
stress-ng: info:  [3589130] successful run completed in 4 mins, 51.53 secs
./stress-ng --resources 0 --resources-procs 4095 --resources-num 4095  10  60.38s user 3302.64s system 1153% cpu 4:51.55 total
```

After fallback to `stress_kill_and_wait_many` suggested by this MR:

```
$ time ./stress-ng --resources 0 --resources-procs 4095 --resources-num 4095 --timeout 10 
stress-ng: info:  [4103668] setting to a 10 secs run per stressor
stress-ng: info:  [4103668] dispatching hogs: 12 resources
stress-ng: info:  [4103669] resources: using 4095 resources and spawning 4095 child processes per instance
stress-ng: info:  [4103681] resources: freeing resources (make take a while)

stress-ng: info:  [4103668] skipped: 0
stress-ng: info:  [4103668] passed: 12: resources (12)
stress-ng: info:  [4103668] failed: 0
stress-ng: info:  [4103668] metrics untrustworthy: 0
stress-ng: info:  [4103668] successful run completed in 10.29 secs
./stress-ng --resources 0 --resources-procs 4095 --resources-num 4095  10  20.13s user 93.43s system 1102% cpu 10.301 total
```

On slow target platforms, the difference is even more visible. I mentioned this issue and a draft change in my previous MR https://github.com/ColinIanKing/stress-ng/pull/602, but that note seems to have slipped through the cracks. So I suggest considering this fallback here.

Regards,
Sergey

