### PR TITLE
stress-af-alg: handle ENOSYS errno on setsockopt ALG_SET_KEY

### DIFF
--- a/stress-af-alg.c
+++ b/stress-af-alg.c
@@ -293,6 +293,10 @@ retry_bind:
 				rc = EXIT_SUCCESS;
 				goto err;
 			}
+			if (errno == ENOSYS) {
+				rc = EXIT_SUCCESS;
+				goto err;
+			}
 			pr_fail("%s: %s (%s): setsockopt ALG_SET_KEY failed, errno=%d (%s)\n",
 				args->name, info->name, info->type, errno, strerror(errno));
 			rc = EXIT_FAILURE;


### PR DESCRIPTION
Some hash algorithms (e.g., sha1, sha256) do not support ALG_SET_KEY. When this happens, setsockopt returns ENOSYS. Currently, this case is treated as a failure. As a result, every retry is counted as an error. After 5 such retries, the stress process aborts, even though the operation is simply not supported by the system. Handle ENOSYS the same way as ENOPROTOOPT and EINVAL, and exit gracefully instead of treating it as a failure.