### PR TITLE
core-hash: add missing PRAGMA_UNROLL_N(4) to stress_hash_coffin()

### DIFF
--- a/core-hash.c
+++ b/core-hash.c
@@ -379,7 +379,7 @@ PRAGMA_UNROLL_N(4)
 uint32_t PURE OPTIMIZE3 stress_hash_coffin(const char *str)
 {
 	register uint32_t result = 0x55555555;
-
+PRAGMA_UNROLL_N(4)
 	while (*str) {
 		result ^= (uint8_t)*str++;
 		result = shim_rol32n(result, 5);


### PR DESCRIPTION
## Summary
Add the missing `PRAGMA_UNROLL_N(4)` loop unroll hint to `stress_hash_coffin()` in `core-hash.c`.

## Problem
`stress_hash_coffin()` is the **only** string-hashing function in `core-hash.c` that does not use `PRAGMA_UNROLL_N()`. Every other comparable hash function (`djb2a`, `fnv1a`, `sdbm`, `nhash`, `kandr`, `loselose`, `knuth`, `x17`, `sedgwick`, `sobel`, `crc32c`, `adler32`, `muladd32`, `muladd64`, `mulxror64`, `mulxror32`, `xorror64`, `xorror32`) already uses `PRAGMA_UNROLL_N(4)` or `PRAGMA_UNROLL_N(8)` on their main loops.

## Fix
Add `PRAGMA_UNROLL_N(4)` before the `while (*str)` loop, consistent with the rest of the file.

The optimized `coffin32_le` and `coffin32_be` variants don't need it because they manually unroll 4 bytes per iteration, but the base `coffin()` function processes one byte at a time and benefits from compiler-assisted unrolling.

## Risk
Essentially zero -- `PRAGMA_UNROLL_N` is a compiler hint that the compiler can safely ignore if unrolling is not beneficial for a given target.