### PR TITLE
stress-sock: fix AF_UNIX socket creation failure due to bad protocol

### DIFF
--- a/stress-sock.c
+++ b/stress-sock.c
@@ -1385,6 +1385,9 @@ static int stress_sock(stress_args_t *args)
 	sock_protocol = stress_setting_get("sock-protocol", &idx) ?
 		sock_options_protocols[idx].optval : IPPROTO_TCP;
 
+	if (sock_domain == AF_UNIX)
+		sock_protocol = 0;
+
 #if !defined(MSG_ZEROCOPY)
 	if (sock_zerocopy)
 		pr_inf("sock: cannot enable sock-zerocopy, MSG_ZEROCOPY is not available\n");


### PR DESCRIPTION
Since commit de797cb43 ("stress-sock: add --sock-protocol option"), socket() is called with IPPROTO_TCP as the default protocol. This breaks --sock-domain unix because AF_UNIX sockets only accept protocol 0, causing socket() to fail with EPROTONOSUPPORT.

Force protocol to 0 when the domain is AF_UNIX.

Fixes: de797cb43 ("stress-sock: add --sock-protocol option (tcp or mptcp allowed)")