### PR TITLE
pthread, membarrier, sem: Fix race in passing arguments to stressors.

### DIFF
--- a/stress-membarrier.c
+++ b/stress-membarrier.c
@@ -152,8 +152,8 @@ static int stress_membarrier(stress_args_t *args)
 	int ret, rc = EXIT_SUCCESS;
 	/* We have MAX_MEMBARRIER_THREADS plus the stressor process */
 	membarrier_info_t info[MAX_MEMBARRIER_THREADS + 1];
+	stress_pthread_args_t pargs[MAX_MEMBARRIER_THREADS + 1];
 	size_t i;
-	stress_pthread_args_t pargs = { args, NULL, 0 };
 	double duration = 0.0, count = 0.0, rate;
 
 	ret = shim_membarrier(MEMBARRIER_CMD_QUERY, 0, 0);
@@ -186,10 +186,12 @@ static int stress_membarrier(stress_args_t *args)
 	keep_running = true;
 
 	for (i = 0; i < MAX_MEMBARRIER_THREADS; i++) {
-		pargs.data = &info[i];
+		pargs[i].args = args;
+		pargs[i].data = &info[i];
+		pargs[i].pthread_ret = 0;
 		info[i].pthread_ret =
 			pthread_create(&info[i].pthread, NULL,
-				stress_membarrier_thread, (void *)&pargs);
+				stress_membarrier_thread, (void *)&pargs[i]);
 	}
 
 	stress_proc_state_set(args->name, STRESS_STATE_SYNC_WAIT);

--- a/stress-pthread.c
+++ b/stress-pthread.c
@@ -76,6 +76,7 @@ static volatile bool keep_thread_running_flag;
 static volatile bool keep_running_flag;
 static uint64_t pthread_count;
 static stress_pthread_info_t pthreads[MAX_PTHREAD];
+static stress_pthread_args_t pthread_args[MAX_PTHREAD];
 
 #endif
 
@@ -432,7 +433,6 @@ static int stress_pthread(stress_args_t *args)
 	uint64_t limited = 0, attempted = 0, maximum = 0;
 	uint64_t pthread_max = DEFAULT_PTHREAD;
 	int ret;
-	stress_pthread_args_t pargs = { args, NULL, 0 };
 	sigset_t set;
 	double count = 0.0, duration = 0.0, average;
 #if defined(HAVE_PTHREAD_MUTEXATTR_T) &&		\
@@ -525,12 +525,15 @@ static int stress_pthread(stress_args_t *args)
 		for (i = 0; i < pthread_max; i++) {
 			if (UNLIKELY(!(keep_running() && stress_continue(args))))
 				break;
-			pargs.data = (void *)&pthreads[i];
+
+			pthread_args[i].args = args;
+			pthread_args[i].data = (void *)&pthreads[i];
+			pthread_args[i].pthread_ret = 0;
 
 			pthreads[i].t_create = stress_time_now();
 			pthreads[i].t_run = pthreads[i].t_create;
 			pthreads[i].ret = pthread_create(&pthreads[i].pthread, NULL,
-				stress_pthread_func, (void *)&pargs);
+				stress_pthread_func, (void *)&pthread_args[i]);
 			if (UNLIKELY(pthreads[i].ret)) {
 				/* Out of resources, don't try any more */
 				if (pthreads[i].ret == EAGAIN) {

--- a/stress-sem.c
+++ b/stress-sem.c
@@ -64,6 +64,7 @@ static sem_t *sem;
 static int sem_global_errno;
 
 static stress_sem_pthread_t sem_pthreads[MAX_SEM_POSIX_PROCS] ALIGN64;
+static stress_pthread_args_t sem_pthread_args[MAX_SEM_POSIX_PROCS] ALIGN64;
 
 static void stress_sem_init(const uint32_t instances)
 {
@@ -207,7 +208,6 @@ static int stress_sem(stress_args_t *args)
 	uint64_t i;
 	bool created = false;
 	bool sem_shared = false;
-	stress_pthread_args_t p_args;
 	double wait_count = 0;
 	double trywait_count = 0;
 	double timedwait_count = 0;
@@ -254,10 +254,12 @@ static int stress_sem(stress_args_t *args)
 		sem_pthreads[i].timedwait_count = 0.0;
 		sem_pthreads[i].wait_count = 0.0;
 
-		p_args.args = args;
-		p_args.data = &sem_pthreads[i];
+		sem_pthread_args[i].args = args;
+		sem_pthread_args[i].data = &sem_pthreads[i];
+		sem_pthread_args[i].pthread_ret = 0;
+
 		sem_pthreads[i].ret = pthread_create(&sem_pthreads[i].pthread, NULL,
-                                stress_sem_thrash, (void *)&p_args);
+                                stress_sem_thrash, (void *)&sem_pthread_args[i]);
 		if ((sem_pthreads[i].ret) && (sem_pthreads[i].ret != EAGAIN)) {
 			pr_fail("%s: pthread create failed, errno=%d (%s)\n",
 				args->name, sem_pthreads[i].ret, strerror(sem_pthreads[i].ret));


### PR DESCRIPTION
There is a data race during startup of the stressors pthread, membarrier, and sem. This becomes apparent under very high load, when threads are likely to begin executing long after they have been created.

The thread-starting loop re-uses a single local variable (stress_pthread_args_t pargs, or p_args in sem) to pass arguments to each thread but does not wait until the thread has read its arguments. Thus, one thread reading its arguments races with the setup of the arguments for the next thread(s).

Rather than synchronising with each new thread, the easier way to fix this issue is to use separate stress_pthread_args_t variables for each thread, which is what the attached patch does. The same approach is already used by stress-inode-flags.

Other stressors do use one shared stress_pthread_args_t variable for all threads spawned, but the contents of the variable is loop-invariant, so the issue does not occur.