### PR TITLE
core-asm-riscv: emit readable cbo.zero/cbo.clean/cbo.flush mnemonics

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1269,6 +1269,7 @@ cpufeatures: \
 	ASM_RISCV_SFENCE_VMA \
 	ASM_RISCV_CBO_ZERO \
 	ASM_RISCV_CBO_CACHE_MANAGEMENT \
+	ASM_RISCV_CBO_MNEMONIC \
 	ASM_S390_PTLB \
 	ASM_SH4_RTE \
 	ASM_SH4_SLEEP \
@@ -1523,6 +1524,9 @@ ASM_RISCV_CBO_ZERO:
 
 ASM_RISCV_CBO_CACHE_MANAGEMENT:
 	$(call check,test-asm-riscv-cbom,HAVE_ASM_RISCV_CBO_CACHE_MANAGEMENT,RISC-V cbom instructions)
+
+ASM_RISCV_CBO_MNEMONIC:
+	$(call check,test-asm-riscv-cbo-mnemonic,HAVE_ASM_RISCV_CBO_MNEMONIC,RISC-V cbo mnemonics)
 
 ASM_S390_PTLB:
 	$(call check,test-asm-s390-ptlb,HAVE_ASM_S390_PTLB,s390 ptlb instruction)

--- a/core-asm-riscv.h
+++ b/core-asm-riscv.h
@@ -97,24 +97,53 @@ static inline void ALWAYS_INLINE stress_asm_riscv_pause(void)
 #if defined(HAVE_ASM_RISCV_CBO_ZERO)
 static inline void ALWAYS_INLINE stress_asm_riscv_cbo_zero(char *addr)
 {
+#if defined(HAVE_ASM_RISCV_CBO_MNEMONIC)
+        /* new assembler: use the mnemonic, it disassembles readably */
+        __asm__ __volatile__(
+        ".option push\n"
+        ".option arch, +zicboz\n"
+        "cbo.zero (%0)\n"
+        ".option pop\n"
+        : : "r" (addr) : "memory");
+#else
+        /* old assembler: hand-encoded word, shows as .word in disassembly */
         __asm__ __volatile__(
         "mv     a0, %0\n"
         "li     a1, %1\n"
         ".4byte %2\n"
         : : "r" (addr), "i" (STRESS_ZICBOZ_CBO_ZERO), "i" (MK_CBO(STRESS_ZICBOZ_CBO_ZERO)) : "a0", "a1", "memory");
+#endif
 }
 #endif
 
-/* cbo.zero instruction */
+/* cbo.flush / cbo.clean instructions */
 #if defined(HAVE_ASM_RISCV_CBO_CACHE_MANAGEMENT)
 static inline void ALWAYS_INLINE stress_asm_riscv_cbo_flush(const void *addr)
 {
+#if defined(HAVE_ASM_RISCV_CBO_MNEMONIC)
+	__asm__ __volatile__(
+	".option push\n"
+	".option arch, +zicbom\n"
+	"cbo.flush (%0)\n"
+	".option pop\n"
+	: : "r" (addr) : "memory");
+#else
 	CBO_INSN(addr, STRESS_ZICBOM_CBO_FLUSH);
+#endif
 }
 
 static inline void ALWAYS_INLINE stress_asm_riscv_cbo_clean(const void *addr)
 {
+#if defined(HAVE_ASM_RISCV_CBO_MNEMONIC)
+	__asm__ __volatile__(
+	".option push\n"
+	".option arch, +zicbom\n"
+	"cbo.clean (%0)\n"
+	".option pop\n"
+	: : "r" (addr) : "memory");
+#else
 	CBO_INSN(addr, STRESS_ZICBOM_CBO_CLEAN);
+#endif
 }
 #endif
 

--- a/test/test-asm-riscv-cbo-mnemonic.c
+++ b/test/test-asm-riscv-cbo-mnemonic.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026      SpacemiT, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ *  Check if the assembler knows the cbo.zero, cbo.clean and cbo.flush
+ *  mnemonics. The ".option arch" directive turns on the extensions just
+ *  for this code, so the global -march does not need them.
+ *  Old assemblers fail this check and stress-ng uses the raw .4byte encoding.
+ */
+
+static void cbo_zero(char *addr)
+{
+	__asm__ __volatile__(
+	".option push\n"
+	".option arch, +zicboz\n"
+	"cbo.zero (%0)\n"
+	".option pop\n"
+	: : "r" (addr) : "memory");
+}
+
+static void cbo_clean(const void *addr)
+{
+	__asm__ __volatile__(
+	".option push\n"
+	".option arch, +zicbom\n"
+	"cbo.clean (%0)\n"
+	".option pop\n"
+	: : "r" (addr) : "memory");
+}
+
+static void cbo_flush(const void *addr)
+{
+	__asm__ __volatile__(
+	".option push\n"
+	".option arch, +zicbom\n"
+	"cbo.flush (%0)\n"
+	".option pop\n"
+	: : "r" (addr) : "memory");
+}
+
+static char mem[64] __attribute__((aligned(64)));
+
+#if defined(__riscv) || \
+    defined(__riscv__)
+int main(void)
+{
+	cbo_zero(mem);
+	cbo_clean(mem);
+	cbo_flush(mem);
+
+	return 0;
+}
+#else
+#error not RISC-V so no cache block operation instructions
+#endif


### PR DESCRIPTION
The cbo helpers hand-encode with .4byte, so objdump shows ".word 0x..." instead of the mnemonic. Use the mnemonics when the assembler knows them, wrapped in ".option arch" so they assemble regardless of -march. Old assemblers fail the new build-time check and keep the .4byte fallback, so their output is unchanged.