### PR TITLE
core-asm-riscv: emit readable pause mnemonic

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1267,6 +1267,7 @@ cpufeatures: \
 	ASM_RISCV_FENCE \
 	ASM_RISCV_FENCE_I \
 	ASM_RISCV_SFENCE_VMA \
+	ASM_RISCV_PAUSE_MNEMONIC \
 	ASM_RISCV_CBO_ZERO \
 	ASM_RISCV_CBO_CACHE_MANAGEMENT \
 	ASM_S390_PTLB \
@@ -1517,6 +1518,9 @@ ASM_RISCV_FENCE_I:
 
 ASM_RISCV_SFENCE_VMA:
 	$(call check,test-asm-riscv-sfence-vma,HAVE_ASM_RISCV_SFENCE_VMA,RISC-V sfence.vma instruction)
+
+ASM_RISCV_PAUSE_MNEMONIC:
+	$(call check,test-asm-riscv-pause-mnemonic,HAVE_ASM_RISCV_PAUSE_MNEMONIC,RISC-V pause mnemonic)
 
 ASM_RISCV_CBO_ZERO:
 	$(call check,test-asm-riscv-cbo_zero,HAVE_ASM_RISCV_CBO_ZERO,RISC-V cbo.zero instruction)

--- a/core-asm-riscv.h
+++ b/core-asm-riscv.h
@@ -89,8 +89,14 @@ static inline void ALWAYS_INLINE stress_asm_riscv_fence_i(void)
 /* Pause instruction */
 static inline void ALWAYS_INLINE stress_asm_riscv_pause(void)
 {
+#if defined(HAVE_ASM_RISCV_PAUSE_MNEMONIC)
+	/* new assembler: use the mnemonic, it disassembles readably */
+	__asm__ __volatile__ ("pause");
+#else
+	/* old assembler: hand-encoded word, shows as .word in disassembly */
 	/* pause is encoded as a fence instruction with pred=W, succ=0, and fm=0 */
 	__asm__ __volatile__ (".4byte 0x100000F");
+#endif
 }
 
 /* cbo.zero instruction */

--- a/test/test-asm-riscv-pause-mnemonic.c
+++ b/test/test-asm-riscv-pause-mnemonic.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026      SpacemiT, Ltd.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ *  Check if the assembler knows the pause mnemonic. It is a hint encoded as
+ *  a FENCE, so no .option arch is needed. Old assemblers fail this check and
+ *  stress-ng uses the raw .4byte encoding instead, which shows as .word in
+ *  disassembly rather than pause.
+ */
+
+#if defined(__riscv) || \
+    defined(__riscv__)
+int main(void)
+{
+	__asm__ __volatile__("pause" ::: "memory");
+
+	return 0;
+}
+#else
+#error not RISC-V so no pause instruction
+#endif


### PR DESCRIPTION
stress_asm_riscv_pause() hand-encodes with .4byte, so objdump shows ".word 0x0100000f" instead of "pause". Use the mnemonic when the assembler knows it (pause is a FENCE hint, no .option arch needed). Old assemblers fail the new build-time check and keep the .4byte fallback, so their output is unchanged.