### PR TITLE
stress-ovpn: fix socket fd leak / stack overflow and guard missing UAPI definitions

### DIFF
--- a/stress-ovpn.c
+++ b/stress-ovpn.c
@@ -1376,6 +1376,9 @@ static void ovpn_ctx_reset(ovpn_ctx_t *ovpn)
 {
 	const char *args_name = ovpn->args_name;
 
+	if (ovpn->socket >= 0)
+		(void)close(ovpn->socket);
+
 	(void)shim_memset(ovpn, 0, sizeof(*ovpn));
 
 	ovpn->args_name = args_name;

--- a/stress-ovpn.c
+++ b/stress-ovpn.c
@@ -83,7 +83,25 @@ static const stress_help_t help[] = {
 #define nla_nest_start(_msg, _type) \
 	nla_nest_start(_msg, (_type) | NLA_F_NESTED)
 
+#ifndef IFLA_OVPN_MAX
+
+enum ovpn_mode
+{
+    OVPN_MODE_P2P,
+    OVPN_MODE_MP,
+};
+
+enum ovpn_ifla_attrs
+{
+    IFLA_OVPN_UNSPEC = 0,
+    IFLA_OVPN_MODE,
+
+    __IFLA_OVPN_MAX,
+};
+
 #define IFLA_OVPN_MAX (__IFLA_OVPN_MAX - 1)
+
+#endif /* ifndef IFLA_OVPN_MAX */
 
 #define RT_SNDBUF_SIZE (1024 * 2)
 #define RT_RCVBUF_SIZE (1024 * 4)


### PR DESCRIPTION
Hi Colin, here's two related fixes for the ovpn stressor, in separate commits.

### Guard IFLA_OVPN_* / ovpn_mode definitions

The stressor relies on enum ovpn_mode (OVPN_MODE_P2P/MP) and the rtnetlink
link attributes IFLA_OVPN_MODE / IFLA_OVPN_MAX to create the ovpn netdev.
Not every installed linux/ovpn.h ships these: a header can expose the genl
API and still be missing them. Without the #if defined block the stressor
won't build against those headers, so I've added the fallback definitions
in-source under #ifndef IFLA_OVPN_MAX to keep it compiling everywhere.

### Close the per-iteration socket

The stressor eventually aborts with a stack-smashing SIGABRT:

    __stack_chk_fail () at core-stack.c:259
    ovpn_connect (...) at stress-ovpn.c
    ...
    Stack overflow detected! Aborting stress-ng.

CMD_CONNECT and CMD_NEW_PEER open a socket and stash the fd in ovpn->socket,
but that fd was only closed once, at teardown. Each loop iteration goes
through ovpn_ctx_reset(), which memset()s the context and puts
ovpn->socket back to -1 without closing the old descriptor first, so every
opened socket leaks one fd.

Given enough time the fd numbers climb past FD_SETSIZE, and once socket()
hands back a value that large the FD_SET(s, &wfds) in ovpn_connect() writes
past the end of the on-stack fd_set. That clobbers the stack canary and
trips __stack_chk_fail().

The fix closes ovpn->socket in ovpn_ctx_reset() before the context is
wiped, so the descriptor is released before the field gets reused. The last
socket is still closed at teardown as before.