### PR TITLE
github workflows: ci-builds: change FreeBSD build from cross to native

### DIFF
--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -1,6 +1,5 @@
 name: Build stress-ng on various platforms
 # Build recipes partly borrowed from 'smartmontools/smartmontools'.
-# Docker image borrowed from 'smartmontools/docker-build'.
 
 on:
   workflow_dispatch:
@@ -8,7 +7,7 @@ on:
       platforms:
         description: Build platforms (defaults to all)
         required: false
-        default: ubuntu-x86_64 ubuntu-x86_64-clang ubuntu-arm64 freebsd-14 macos cygwin
+        default: ubuntu-x86_64 ubuntu-x86_64-clang ubuntu-arm64 freebsd macos cygwin
       libs-ubuntu:
         description: "Additional libraries for Ubuntu or 'none'"
         required: false
@@ -107,22 +106,27 @@ jobs:
           path: stress-ng
           retention-days: 30
 
-  build-freebsd-14:
-    if: ${{ contains(github.event.inputs.platforms, 'freebsd-14') }}
+  build-freebsd:
+    if: ${{ contains(github.event.inputs.platforms, 'freebsd') }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/smartmontools/docker-build:master
     steps:
       - uses: actions/checkout@v7
-      - name: Build
-        run: |
-          target="-target x86_64-unknown-freebsd14 --sysroot=/opt/cross-freebsd-14/" &&
-          make ${{ github.event.inputs.make-options }} \
-            CC="clang $target" CXX="clang++ $target" \
-            CPPFLAGS="-isystem /opt/cross-freebsd-14/usr/include/c++/v1"
+      - name: Build and Run (QEMU)
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true # use 'sh' instead of 'tcsh'
+          prepare: |  # does not work with BSD make
+            pkg update
+            pkg install -y gmake
+          run: |
+            set -e
+            gmake ${{ github.event.inputs.make-options }}
+            ./stress-ng --version
+            ./stress-ng ${{ github.event.inputs.check-options }} ||
+            echo '::error:: ./stress-ng ${{ github.event.inputs.check-options }} failed'
       - uses: actions/upload-artifact@v7
         with:
-          name: stress-ng-freebsd-14
+          name: stress-ng-freebsd
           path: stress-ng
           retention-days: 30
 

--- a/.github/workflows/ci-builds.yml
+++ b/.github/workflows/ci-builds.yml
@@ -43,13 +43,13 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install -y ${{ github.event.inputs.libs-ubuntu }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: make ${{ github.event.inputs.make-options }}
       - run: ./stress-ng --version
       - run: |
           ./stress-ng ${{ github.event.inputs.check-options }} ||
           echo '::error:: ./stress-ng ${{ github.event.inputs.check-options }} failed'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: stress-ng-ubuntu-x86_64
           path: stress-ng
@@ -64,7 +64,7 @@ jobs:
         if: ${{ github.event.inputs.libs-ubuntu != 'none' }}
         run: |
           sudo apt-get install -y ${{ github.event.inputs.libs-ubuntu }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           scan-build --use-cc="clang" --use-c++="clang++" -o "clang-report" \
             -analyzer-config "stable-report-filename=true" \
@@ -75,12 +75,12 @@ jobs:
       - run: |
           ./stress-ng ${{ github.event.inputs.check-options }} ||
           echo '::error:: ./stress-ng ${{ github.event.inputs.check-options }} failed'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: stress-ng-ubuntu-x86_64-clang
           path: stress-ng
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: stress-ng-ubuntu-x86_64-clang-report
           path: clang-report/*
@@ -95,13 +95,13 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install -y ${{ github.event.inputs.libs-ubuntu }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: make ${{ github.event.inputs.make-options }}
       - run: ./stress-ng --version
       - run: |
           ./stress-ng ${{ github.event.inputs.check-options }} ||
           echo '::error:: ./stress-ng ${{ github.event.inputs.check-options }} failed'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: stress-ng-ubuntu-arm64
           path: stress-ng
@@ -113,14 +113,14 @@ jobs:
     container:
       image: ghcr.io/smartmontools/docker-build:master
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build
         run: |
           target="-target x86_64-unknown-freebsd14 --sysroot=/opt/cross-freebsd-14/" &&
           make ${{ github.event.inputs.make-options }} \
             CC="clang $target" CXX="clang++ $target" \
             CPPFLAGS="-isystem /opt/cross-freebsd-14/usr/include/c++/v1"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: stress-ng-freebsd-14
           path: stress-ng
@@ -130,7 +130,7 @@ jobs:
     if: ${{ contains(github.event.inputs.platforms, 'macos') }}
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           make CFLAGS="-arch arm64 -arch x86_64" CXXFLAGS="-arch arm64 -arch x86_64" \
             ${{ github.event.inputs.make-options }}
@@ -138,7 +138,7 @@ jobs:
       - run: |
           ./stress-ng ${{ github.event.inputs.check-options }} ||
           echo '::error:: ./stress-ng ${{ github.event.inputs.check-options }} failed'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: stress-ng-macos
           path: stress-ng
@@ -152,9 +152,9 @@ jobs:
         with:
           platform: x86_64
           packages: gcc-g++ git make ${{ github.event.inputs.libs-cygwin }}
-        # 'actions/checkout@v4' now uses Cygwin git instead of Windows git.
+        # 'actions/checkout@v7' now uses Cygwin git instead of Windows git.
       - run: git config --global --add safe.directory /cygdrive/d/a/stress-ng/stress-ng
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Done above as the builtin would use a path for Windows git.
           set-safe-directory: false
@@ -166,7 +166,7 @@ jobs:
       - run: |
           ./stress-ng ${{ github.event.inputs.check-options }} ||
           echo '::error:: ./stress-ng ${{ github.event.inputs.check-options }} failed'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: stress-ng-cygwin
           path: stress-ng.exe


### PR DESCRIPTION
Runs FreeBSD in QEMU using action provided by https://github.com/vmactions.

----

Test run: https://github.com/chrfranke/stress-ng/actions/runs/30375288254

More platforms could be added if desired. This would also allow to check compatibility with rare BE platforms like FreeBSD PowerPC64 (slow build) or NetBSD Sparc64 (even slower build).

See for example https://github.com/smartmontools/smartmontools/actions/runs/30375615140

----

The first patch updates GitHub actions from v4 to v7 because GH will remove Node.js 20 soon.

----

PS: Interesting unrelated observation from the mentioned test run (on ubuntu-x86_64):
```
$ ./stress-ng --buildinfo --cpu 2 --metrics --timeout 1 --verbose --verify
...
stress-ng: debug: [16748] caught SIGILL, address 0x00005584f4721879 (ILL_ILLOPN)
stress-ng: debug: [16748] stress-ng: info: 0x00005584f4721870: e8 bb f1 eb ff c5 c1 57 ff<62>f1 47 08 7b e3 62
stress-ng: debug: [16748] stress-ng: info: 0x00005584f4721880: f1 47 08 7b c0 c5 db 59 25 fb be 83 00 c5 fb 11
stress-ng: debug: [16748] stress-ng: info: 0x00005584f4721890: 04 24 c5 fb 11 64 24 10 e8 93 f1 eb ff bb e8 03
stress-ng: debug: [16748] stress-ng: info: 5584f457f000-5584f4ef4000 r-xp 00086000 08:01 8666528 /home/runner/work/stress-ng/stress-ng/stress-ng
stress-ng: debug: [16750] caught SIGILL, address 0x00005584f4721879 (ILL_ILLOPN)
stress-ng: debug: [16750] stress-ng: info: 0x00005584f4721870: e8 bb f1 eb ff c5 c1 57 ff<62>f1 47 08 7b e3 62
stress-ng: debug: [16750] stress-ng: info: 0x00005584f4721880: f1 47 08 7b c0 c5 db 59 25 fb be 83 00 c5 fb 11
stress-ng: debug: [16750] stress-ng: info: 0x00005584f4721890: 04 24 c5 fb 11 64 24 10 e8 93 f1 eb ff bb e8 03
stress-ng: error: [16745] cpu: [16748] terminated with an error, exit status=2 (stressor failed)
stress-ng: debug: [16745] cpu: [16748] terminated (stressor failed)
stress-ng: debug: [16750] stress-ng: info: 5584f457f000-5584f4ef4000 r-xp 00086000 08:01 8666528 /home/runner/work/stress-ng/stress-ng/stress-ng
stress-ng: error: [16745] cpu: [16750] terminated with an error, exit status=2 (stressor failed)
stress-ng: debug: [16745] cpu: [16750] terminated (stressor failed)
stress-ng: info:  [16745] unsuccessful run completed in 0 secs
```
