### PR TITLE
stress-unlink: fix fd leak on hard link paths

### DIFF
--- a/stress-unlink.c
+++ b/stress-unlink.c
@@ -103,8 +103,7 @@ static void stress_unlink_exercise(
 			if (UNLIKELY((i & 7) == 7)) {
 				if (link(filenames[i - 1], filenames[i]) == 0) {
 					fds[i] = open(filenames[i], O_RDWR);
-					if (fds[i] < 0)
-						continue;
+					continue;
 				}
 			}
 retry:


### PR DESCRIPTION
When open() succeeds after link(), the code falls through and opens the same file again, leaking the first fd.

Unconditionally continue after open() to avoid the leakage.