### PR TITLE
stress-ovpn: fix the uapi gate, an unbounded netlink wait and the exercises table

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -2819,6 +2819,7 @@ functions: \
 	LGAMMAL \
 	LGETXATTR \
 	LINKAT \
+	LINUX_OVPN_UAPI \
 	LISTXATTR \
 	LISTXATTRAT \
 	LLISTXATTR \
@@ -4272,6 +4273,9 @@ LGETXATTR:
 
 LINKAT:
 	$(call check,test-linkat,HAVE_LINKAT,linkat)
+
+LINUX_OVPN_UAPI:
+	$(call check,test-linux-ovpn-uapi,HAVE_LINUX_OVPN_UAPI,linux/ovpn.h uapi)
 
 LISTXATTR:
 	$(call check,test-listxattr,HAVE_LISTXATTR,listxattr)

--- a/stress-ovpn.c
+++ b/stress-ovpn.c
@@ -29,10 +29,17 @@ static const stress_help_t help[] = {
 
 /*
  * static builds with libnl require getprotobynumber_r
- * which is not supported as a static lib at present
+ * which is not supported as a static lib at present.
+ *
+ * HAVE_LINUX_OVPN_UAPI rather than HAVE_LINUX_OVPN_H: the header travelled
+ * through several out-of-tree revisions before ovpn was merged in 6.16, so
+ * its mere presence does not imply it declares the commands and attributes
+ * used below. The configure test references them, so an older or partial
+ * copy makes the stressor report itself unimplemented instead of failing
+ * the build.
  */
 #if defined(HAVE_LIB_NL) &&		\
-    defined(HAVE_LINUX_OVPN_H) &&	\
+    defined(HAVE_LINUX_OVPN_UAPI) &&	\
     !defined(BUILD_STATIC)
 
 #include <time.h>
@@ -82,8 +89,6 @@ static const stress_help_t help[] = {
  */
 #define nla_nest_start(_msg, _type) \
 	nla_nest_start(_msg, (_type) | NLA_F_NESTED)
-
-#define IFLA_OVPN_MAX (__IFLA_OVPN_MAX - 1)
 
 #define RT_SNDBUF_SIZE (1024 * 2)
 #define RT_RCVBUF_SIZE (1024 * 4)
@@ -1641,7 +1646,7 @@ const stressor_info_t stress_ovpn_info = {
 	.classifier = CLASS_NETWORK | CLASS_OS,
 	.verify = VERIFY_NONE,
 	.help = help,
-	.unimplemented_reason = "built without libnl3 or linux/ovpn.h support or build statically"
+	.unimplemented_reason = "built without libnl3, without a linux/ovpn.h providing the ovpn netlink uapi, or built statically"
 };
 
-#endif /* HAVE_LIB_NL && HAVE_LINUX_OVPN_H */
+#endif /* HAVE_LIB_NL && HAVE_LINUX_OVPN_UAPI */

--- a/stress-ovpn.c
+++ b/stress-ovpn.c
@@ -92,6 +92,13 @@ static const stress_help_t help[] = {
 
 #define RT_SNDBUF_SIZE (1024 * 2)
 #define RT_RCVBUF_SIZE (1024 * 4)
+/*
+ * A reply is not guaranteed to arrive: the kernel can fail to allocate one
+ * under memory pressure, and the request may have been aimed at an object that
+ * went away. Without a deadline the recvmsg() loop in ovpn_rt_send() waits for
+ * it indefinitely, which hangs the worker.
+ */
+#define RT_RCVTIMEO_SEC (5)
 
 #define KEY_LEN		(256 / 8)
 #define NONCE_LEN	(8)
@@ -252,6 +259,7 @@ static inline void ovpn_nest_end(struct nlmsghdr *msg, struct rtattr *nest)
 static int ovpn_rt_socket(ovpn_ctx_t *ovpn)
 {
 	const char *args_name = ovpn->args_name;
+	struct timeval rcvtimeo = { RT_RCVTIMEO_SEC, 0 };
 	int sndbuf = RT_SNDBUF_SIZE;
 	int rcvbuf = RT_RCVBUF_SIZE;
 	int fd;
@@ -274,6 +282,18 @@ static int ovpn_rt_socket(ovpn_ctx_t *ovpn)
 	if (setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf,
 		       sizeof(rcvbuf)) < 0) {
 		pr_dbg("%s: setsockopt SO_RCVBUF failed, errno=%d (%s)\n",
+			args_name, errno, strerror(errno));
+		(void)close(fd);
+		return -1;
+	}
+
+	/*
+	 * Bound the wait for a reply. This is what turns a lost reply into an
+	 * error the caller can act on, rather than a worker that never returns.
+	 */
+	if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rcvtimeo,
+		       sizeof(rcvtimeo)) < 0) {
+		pr_dbg("%s: setsockopt SO_RCVTIMEO failed, errno=%d (%s)\n",
 			args_name, errno, strerror(errno));
 		(void)close(fd);
 		return -1;
@@ -357,7 +377,7 @@ static int ovpn_rt_send(
 
 	payload->nlmsg_seq = (uint32_t)(time(NULL) & 0xffffffff);
 
-	/* no need to send reply */
+	/* no reply parser, so ask for a plain ack */
 	if (!cb)
 		payload->nlmsg_flags |= NLM_F_ACK;
 
@@ -393,8 +413,29 @@ static int ovpn_rt_send(
 		iov.iov_len = sizeof(buf);
 		rcv_len = recvmsg(fd, &nlmsg, 0);
 		if (rcv_len < 0) {
-			if (errno == EINTR || errno == EAGAIN) {
-				pr_dbg("interrupted call\n");
+			/*
+			 * With SO_RCVTIMEO set, EAGAIN means the deadline
+			 * expired rather than "try again": the reply is not
+			 * coming, so report it instead of asking for it again
+			 * forever.
+			 */
+			if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+				pr_dbg("%s: no netlink reply within %d seconds\n",
+					args_name, RT_RCVTIMEO_SEC);
+				ret = -ETIMEDOUT;
+				goto out;
+			}
+			if (errno == EINTR) {
+				/*
+				 * Retrying is right for a signal, but not once
+				 * the run is winding down: SIGALRM would then
+				 * be swallowed on every iteration and the
+				 * worker would never notice it has to stop.
+				 */
+				if (UNLIKELY(!stress_continue_flag())) {
+					ret = -EINTR;
+					goto out;
+				}
 				continue;
 			}
 			pr_dbg("%s: recvmsg() failed\n", args_name);

--- a/stress-ovpn.c
+++ b/stress-ovpn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Gianmarco De Gregori <gianmarco@mandelbit.com>
+ * Copyright (C) 2025-2026 Gianmarco De Gregori <gianmarco@mandelbit.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -1612,12 +1612,12 @@ static int stress_ovpn(stress_args_t *args)
 
 static const stress_exercises_t exercises[] = {
 	STRESS_EX_SYSCALL("bind"),
-	STRESS_EX_SYSCALL("connext"),
+	STRESS_EX_SYSCALL("connect"),
 	STRESS_EX_SYSCALL("getsockname"),
-	STRESS_EX_SYSCALL("pselect"),
 	STRESS_EX_SYSCALL("recvmsg"),
+	STRESS_EX_SYSCALL("select"),
 	STRESS_EX_SYSCALL("sendmsg"),
-	STRESS_EX_SYSCALL("setsockoopt"),
+	STRESS_EX_SYSCALL("setsockopt"),
 	STRESS_EX_SYSCALL("socket"),
 
 	STRESS_EX_LIBRARY("nl"),

--- a/test/test-linux-ovpn-uapi.c
+++ b/test/test-linux-ovpn-uapi.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026      Gianmarco De Gregori
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+#if !defined(__linux__)
+#error requires linux to build
+#endif
+
+#include <linux/ovpn.h>
+#include <linux/if_link.h>
+
+/*
+ *  The presence of linux/ovpn.h says nothing about what it contains: the
+ *  header travelled through several out-of-tree revisions before ovpn was
+ *  merged in 6.16, and a system can easily have an older or partial copy of
+ *  it. Reference the generic netlink commands and attributes the stressor
+ *  actually uses, so a header that predates them makes the stressor report
+ *  itself unimplemented rather than failing the build.
+ *
+ *  linux/ovpn.h is not the whole uapi the stressor needs, though.
+ *  IFLA_OVPN_MODE selects the interface mode and is an rtnetlink link
+ *  attribute, so it lives in linux/if_link.h alongside every other link
+ *  type's attributes. The two headers come from different subsystems and can
+ *  be at different versions: a distribution can ship a complete linux/ovpn.h
+ *  next to an if_link.h predating 6.16, where the attribute was added, and
+ *  gating on the former alone lets such a system into the ovpn block and then
+ *  fails its build on the latter. Test both here so the outcome is the
+ *  unimplemented report either way.
+ *
+ *  IFLA_OVPN_MODE is an enumerator rather than a macro, so #if defined()
+ *  cannot see it and its presence has to be compiled.
+ */
+int main(void)
+{
+	static const char *family = OVPN_FAMILY_NAME;
+	const int link_attr = IFLA_OVPN_MODE;
+	const enum ovpn_cipher_alg ciphers[] = {
+		OVPN_CIPHER_ALG_NONE, OVPN_CIPHER_ALG_AES_GCM,
+	};
+	const enum ovpn_key_slot slots[] = {
+		OVPN_KEY_SLOT_PRIMARY,
+	};
+	const int cmds[] = {
+		OVPN_CMD_PEER_NEW, OVPN_CMD_PEER_SET, OVPN_CMD_PEER_GET,
+		OVPN_CMD_PEER_DEL, OVPN_CMD_KEY_NEW, OVPN_CMD_KEY_GET,
+		OVPN_CMD_KEY_SWAP, OVPN_CMD_KEY_DEL,
+	};
+	const int attrs[] = {
+		OVPN_A_IFINDEX, OVPN_A_PEER, OVPN_A_KEYCONF,
+		OVPN_A_PEER_ID, OVPN_A_PEER_SOCKET,
+		OVPN_A_PEER_REMOTE_IPV4, OVPN_A_PEER_REMOTE_IPV6,
+		OVPN_A_PEER_REMOTE_IPV6_SCOPE_ID,
+		OVPN_A_PEER_REMOTE_PORT, OVPN_A_PEER_VPN_IPV4,
+		OVPN_A_PEER_VPN_IPV6, OVPN_A_PEER_KEEPALIVE_INTERVAL,
+		OVPN_A_PEER_KEEPALIVE_TIMEOUT,
+		OVPN_A_KEYCONF_PEER_ID, OVPN_A_KEYCONF_SLOT,
+		OVPN_A_KEYCONF_KEY_ID, OVPN_A_KEYCONF_CIPHER_ALG,
+		OVPN_A_KEYCONF_ENCRYPT_DIR, OVPN_A_KEYCONF_DECRYPT_DIR,
+		OVPN_A_KEYDIR_CIPHER_KEY, OVPN_A_KEYDIR_NONCE_TAIL,
+	};
+
+	(void)family;
+	(void)ciphers;
+	(void)slots;
+	(void)cmds;
+	(void)attrs;
+	(void)link_attr;
+
+	return OVPN_A_MAX + OVPN_A_PEER_MAX + OVPN_A_KEYCONF_MAX;
+}


### PR DESCRIPTION
Hi Colin, here's three fixes to the existing ovpn stressor, independent of each other 
and of any new functionality, so I have split them out rather than burying them under a
larger change.

Two of them are bugs someone would actually hit.

The ovpn block is enabled by HAVE_LINUX_OVPN_H, which check_header sets by
compiling nothing more than the #include. That says very little about what the
header contains, and the stressor names some forty of its commands and
attributes, so an older or partial copy passes the check and then fails the
build instead of compiling the stressor out. IFLA_OVPN_MODE is not even in that
header to begin with: it lives in linux/if_link.h, which is versioned
independently and can be the older of the two. I have replaced the check with a
configure test that references the symbols actually used, so a system missing
any of them reports the stressor unimplemented, which is what the guard was
there to do in the first place.

Separately, ovpn_rt_send() retried EINTR unconditionally, so the SIGALRM that
ends the run was swallowed on every iteration and the worker never learned it
had to stop. A --timeout run outlived its own timeout and needed an external
SIGKILL to clear, which for a stressor meant to run unattended is the part that
hurts. SO_RCVTIMEO now bounds the wait, and the two errno cases the loop had
merged are handled apart.

The third is cosmetic but it does have an effect. "connext" and "setsockoopt" in
the exercises table are typos, and "pselect" names a call the stressor never
makes; since that table is what --exercise-syscall matches against, all three
entries are dead, and the stressor cannot be selected by the name of a call it
does make.


A second, larger series adding an opt-in --ovpn-tunnel mode, which builds a real
two-endpoint DCO tunnel and exercises the data path rather than only the control
plane, sits on top of these three commits. I will send it once this lands. The
rtnetlink fix is a prerequisite for it in practice but stands on its own, which
is why it is here.