### PR TITLE
core-cpu: only enable AVX-512 if the CPU actually supports it, not by CPU model assumption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -926,7 +926,8 @@ stress-ng: config.h $(OBJS)
 	$(PRE_Q)echo "LD $@"
 	$(eval LINK_TOOL := $(shell if [ -n "$(shell grep '^#define HAVE_EIGEN' config.h)" ]; then echo $(CXX); else echo $(CC); fi))
 	$(eval LDFLAGS_EXTRA := $(shell grep CONFIG_LDFLAGS config | sed 's/CONFIG_LDFLAGS +=//' | tr '\n' ' '))
-	$(PRE_V)$(LINK_TOOL) $(OBJS) -lm $(LDFLAGS) $(LDFLAGS_EXTRA) $(CFLAGS) -o $@
+	$(eval LDFLAGS_WRAP := $(shell if [ -n "$(shell grep '^#define HAVE_LD_WRAP_CPU_INDICATOR_INIT' config.h)" ]; then echo -Wl,--wrap=__cpu_indicator_init; fi))
+	$(PRE_V)$(LINK_TOOL) $(OBJS) -lm $(LDFLAGS) $(LDFLAGS_EXTRA) $(LDFLAGS_WRAP) $(CFLAGS) -o $@
 
 stress-ovpn.o: stress-ovpn.c $(HEADERS) $(HEADERS_GEN)
 	$(PRE_Q)echo "CC $<"

--- a/Makefile.config
+++ b/Makefile.config
@@ -1376,6 +1376,7 @@ cpufeatures: \
 	PRAGMA_NO_HARD_DFP \
 	PRAGMA_PREFETCH	\
 	RESTRICT \
+	LD_WRAP_CPU_INDICATOR_INIT \
 	TARGET_CLONES \
 	TARGET_CLONES_ALDERLAKE \
 	TARGET_CLONES_ARROWLAKE \
@@ -1863,6 +1864,9 @@ TARGET_CLONES_ZNVER4:
 
 TARGET_CLONES_ZNVER5:
 	$(call check,test-target-clones,HAVE_TARGET_CLONES_ZNVER5,target_clones arch=znver5 attribute (x86),,,'"default$(comma)arch=znver5"')
+
+LD_WRAP_CPU_INDICATOR_INIT:
+	$(call check,test-ld-wrap-cpu-indicator-init,HAVE_LD_WRAP_CPU_INDICATOR_INIT,ld --wrap of __cpu_indicator_init (x86),-Wl$(comma)--wrap=__cpu_indicator_init,,)
 
 TARGET_CLONES_POWER9:
 	$(call check,test-target-clones,HAVE_TARGET_CLONES_POWER9,target_clones cpu=power attribute (power9),,,'"default$(comma)cpu=power9"')

--- a/core-cpu.c
+++ b/core-cpu.c
@@ -22,6 +22,7 @@
 #include "core-asm-x86.h"
 #include "core-builtin.h"
 #include "core-cpu.h"
+#include "core-target-clones.h"
 
 #include <sched.h>
 
@@ -955,3 +956,74 @@ void OPTIMIZE3 stress_cpu_fp_subnormals_enable(void)
 		_mm_setcsr(_mm_getcsr() & ~(X86_FP_DAZ | X86_FP_FTZ));
 #endif
 }
+
+#if defined(STRESS_ARCH_X86) &&			\
+    defined(HAVE_TARGET_CLONES) &&		\
+    defined(HAVE_LD_WRAP_CPU_INDICATOR_INIT)
+
+/*
+ *  libgcc's CPU description. The resolvers GCC emits for target_clones
+ *  call __cpu_indicator_init() and then compare __cpu_model.__cpu_subtype
+ *  to pick an "arch=" clone. Layout is fixed by the libgcc ABI.
+ */
+struct stress_cpu_model_t {
+	unsigned int __cpu_vendor;
+	unsigned int __cpu_type;
+	unsigned int __cpu_subtype;
+	unsigned int __cpu_features[1];
+};
+
+extern struct stress_cpu_model_t __cpu_model;
+extern void __real___cpu_indicator_init(void);
+
+void __wrap___cpu_indicator_init(void);
+
+/*
+ *  __wrap___cpu_indicator_init()
+ *	__builtin_cpu_is() picks an "arch=" clone on the family/model in
+ *	__cpu_model alone, never checking that the clone's instructions can
+ *	run. A CPU reporting an AVX-512 model without usable AVX-512 gets EVEX
+ *	code and dies with SIGILL. AVX-512 goes missing when a hypervisor masks
+ *	it, when firmware disables it, or when the kernel skips the xstate.
+ *	Booting with clearcpuid=avx512f reproduces it.
+ *
+ *	Family 6 model 0x55 is the worst case. In
+ *	gcc/common/config/i386/cpuinfo.h "case 0x55" AVX512BF16 selects Cooper
+ *	Lake, AVX512VNNI selects Cascade Lake, anything else falls through to
+ *	skylake-avx512. Those feature bits are xgetbv gated, the subtype is
+ *	not, so masking steers the CPU onto the AVX-512 clone.
+ *
+ *	Clear the classification so no "arch=" clone matches and the feature
+ *	clones or the default are used. Those resolve through
+ *	__builtin_cpu_supports(), which libgcc gates on OSXSAVE plus xgetbv.
+ *	Every other CPU keeps its clone.
+ *
+ *	Runs during ifunc relocation, before main() and before libc is up, so
+ *	it touches nothing but __cpu_model.
+ */
+void __wrap___cpu_indicator_init(void)
+{
+	/* 0: not started, 1: in progress, 2: done */
+	static volatile int state = 0;
+
+	/*
+	 * The builtins below can re-enter this wrapper; let those calls fall
+	 * straight through, libgcc's own initialiser is idempotent.
+	 */
+	if (state != 0) {
+		__real___cpu_indicator_init();
+		return;
+	}
+	state = 1;
+
+	__real___cpu_indicator_init();
+
+	if (TARGET_CLONE_MODELS_CLAIM_AVX512 &&
+	    !__builtin_cpu_supports("avx512f")) {
+		__cpu_model.__cpu_type = 0;
+		__cpu_model.__cpu_subtype = 0;
+	}
+	state = 2;
+}
+
+#endif

--- a/core-target-clones.h
+++ b/core-target-clones.h
@@ -36,6 +36,21 @@
 #if defined(STRESS_ARCH_X86) &&	\
     defined(HAVE_TARGET_CLONES)
 
+/*
+ *  __builtin_cpu_is() picks an "arch=" clone on family/model alone, so an
+ *  AVX-512 clone can land on a CPU that cannot run it.
+ *  __wrap___cpu_indicator_init() in core-cpu.c fixes that but needs a linker
+ *  able to interpose libgcc's initialiser. Without one, drop the AVX-512
+ *  micro-architectures and reach AVX-512 through the "avx512f" feature clone,
+ *  which __builtin_cpu_supports() gates on OSXSAVE plus xgetbv. Only the
+ *  tuning differs between the two, never the instruction set.
+ */
+#if defined(HAVE_LD_WRAP_CPU_INDICATOR_INIT)
+#define TARGET_CLONE_AVX512_BY_ARCH
+#else
+#define TARGET_CLONE_AVX512_BY_FEATURE
+#endif
+
 #if defined(HAVE_TARGET_CLONES_MMX)
 #define TARGET_CLONE_MMX	"mmx",
 #define TARGET_CLONE_USE
@@ -99,28 +114,32 @@
 #define TARGET_CLONE_SSE4_2
 #endif
 
-#if defined(HAVE_TARGET_CLONES_SKYLAKE_AVX512)
+#if defined(HAVE_TARGET_CLONES_SKYLAKE_AVX512) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_SKYLAKE_AVX512	"arch=skylake-avx512",
 #define TARGET_CLONE_USE
 #else
 #define TARGET_CLONE_SKYLAKE_AVX512
 #endif
 
-#if defined(HAVE_TARGET_CLONES_COOPERLAKE)
+#if defined(HAVE_TARGET_CLONES_COOPERLAKE) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_COOPERLAKE	"arch=cooperlake",
 #define TARGET_CLONE_USE
 #else
 #define TARGET_CLONE_COOPERLAKE
 #endif
 
-#if defined(HAVE_TARGET_CLONES_TIGERLAKE)
+#if defined(HAVE_TARGET_CLONES_TIGERLAKE) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_TIGERLAKE	"arch=tigerlake",
 #define TARGET_CLONE_USE
 #else
 #define TARGET_CLONE_TIGERLAKE
 #endif
 
-#if defined(HAVE_TARGET_CLONES_SAPPHIRERAPIDS)
+#if defined(HAVE_TARGET_CLONES_SAPPHIRERAPIDS) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_SAPPHIRERAPIDS "arch=sapphirerapids",
 #define TARGET_CLONE_USE
 #else
@@ -134,7 +153,8 @@
 #define TARGET_CLONE_ALDERLAKE
 #endif
 
-#if defined(HAVE_TARGET_CLONES_ROCKETLAKE)
+#if defined(HAVE_TARGET_CLONES_ROCKETLAKE) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_ROCKETLAKE	"arch=rocketlake",
 #define TARGET_CLONE_USE
 #else
@@ -142,7 +162,8 @@
 #endif
 
 #if defined(HAVE_TARGET_CLONES_GRANITERAPIDS) &&	\
-    defined(HAVE_COMPILER_GCC_OR_MUSL)
+    defined(HAVE_COMPILER_GCC_OR_MUSL) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_GRANITERAPIDS "arch=graniterapids",
 #define TARGET_CLONE_USE
 #else
@@ -150,7 +171,8 @@
 #endif
 
 #if defined(HAVE_TARGET_CLONES_DIAMONDRAPIDS) &&	\
-    defined(HAVE_COMPILER_GCC_OR_MUSL)
+    defined(HAVE_COMPILER_GCC_OR_MUSL) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_DIAMONDRAPIDS "arch=diamondrapids",
 #define TARGET_CLONE_USE
 #else
@@ -182,7 +204,8 @@
 #endif
 
 #if defined(HAVE_TARGET_CLONES_NOVALAKE) &&		\
-    defined(HAVE_COMPILER_GCC_OR_MUSL)
+    defined(HAVE_COMPILER_GCC_OR_MUSL) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_NOVALAKE "arch=novalake",
 #define TARGET_CLONE_USE
 #else
@@ -222,7 +245,8 @@
 #endif
 
 #if defined(HAVE_TARGET_CLONES_ZNVER4) &&		\
-    defined(HAVE_COMPILER_GCC_OR_MUSL)
+    defined(HAVE_COMPILER_GCC_OR_MUSL) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_ZNVER4 "arch=znver4",
 #define TARGET_CLONE_USE
 #else
@@ -230,16 +254,113 @@
 #endif
 
 #if defined(HAVE_TARGET_CLONES_ZNVER5) &&		\
-    defined(HAVE_COMPILER_GCC_OR_MUSL)
+    defined(HAVE_COMPILER_GCC_OR_MUSL) &&	\
+    defined(TARGET_CLONE_AVX512_BY_ARCH)
 #define TARGET_CLONE_ZNVER5 "arch=znver5",
 #define TARGET_CLONE_USE
 #else
 #define TARGET_CLONE_ZNVER5
 #endif
 
+/*
+ *  The "arch=" clones above that are built with AVX-512, checked at run time
+ *  by __wrap___cpu_indicator_init() in core-cpu.c.
+ *
+ *  Add a new "arch=" clone here when
+ *  "gcc -march=<name> -dM -E - < /dev/null" defines __AVX512F__. Compilers
+ *  that accept a name in target_clones accept it in __builtin_cpu_is(), so
+ *  the probes above gate both uses.
+ */
+#define TARGET_CLONE_MODELS_CLAIM_AVX512 (false			\
+	TARGET_CLONE_IS_SKYLAKE_AVX512				\
+	TARGET_CLONE_IS_COOPERLAKE				\
+	TARGET_CLONE_IS_TIGERLAKE				\
+	TARGET_CLONE_IS_ROCKETLAKE				\
+	TARGET_CLONE_IS_SAPPHIRERAPIDS				\
+	TARGET_CLONE_IS_GRANITERAPIDS				\
+	TARGET_CLONE_IS_DIAMONDRAPIDS				\
+	TARGET_CLONE_IS_NOVALAKE				\
+	TARGET_CLONE_IS_ZNVER4					\
+	TARGET_CLONE_IS_ZNVER5					\
+	)
+
+#if defined(HAVE_TARGET_CLONES_SKYLAKE_AVX512)
+#define TARGET_CLONE_IS_SKYLAKE_AVX512	|| __builtin_cpu_is("skylake-avx512")
+#else
+#define TARGET_CLONE_IS_SKYLAKE_AVX512
+#endif
+
+#if defined(HAVE_TARGET_CLONES_COOPERLAKE)
+#define TARGET_CLONE_IS_COOPERLAKE	|| __builtin_cpu_is("cooperlake")
+#else
+#define TARGET_CLONE_IS_COOPERLAKE
+#endif
+
+#if defined(HAVE_TARGET_CLONES_TIGERLAKE)
+#define TARGET_CLONE_IS_TIGERLAKE	|| __builtin_cpu_is("tigerlake")
+#else
+#define TARGET_CLONE_IS_TIGERLAKE
+#endif
+
+#if defined(HAVE_TARGET_CLONES_ROCKETLAKE)
+#define TARGET_CLONE_IS_ROCKETLAKE	|| __builtin_cpu_is("rocketlake")
+#else
+#define TARGET_CLONE_IS_ROCKETLAKE
+#endif
+
+#if defined(HAVE_TARGET_CLONES_SAPPHIRERAPIDS)
+#define TARGET_CLONE_IS_SAPPHIRERAPIDS	|| __builtin_cpu_is("sapphirerapids")
+#else
+#define TARGET_CLONE_IS_SAPPHIRERAPIDS
+#endif
+
+#if defined(HAVE_TARGET_CLONES_GRANITERAPIDS) &&	\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_IS_GRANITERAPIDS	|| __builtin_cpu_is("graniterapids")
+#else
+#define TARGET_CLONE_IS_GRANITERAPIDS
+#endif
+
+#if defined(HAVE_TARGET_CLONES_DIAMONDRAPIDS) &&	\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_IS_DIAMONDRAPIDS	|| __builtin_cpu_is("diamondrapids")
+#else
+#define TARGET_CLONE_IS_DIAMONDRAPIDS
+#endif
+
+#if defined(HAVE_TARGET_CLONES_NOVALAKE) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_IS_NOVALAKE	|| __builtin_cpu_is("novalake")
+#else
+#define TARGET_CLONE_IS_NOVALAKE
+#endif
+
+#if defined(HAVE_TARGET_CLONES_ZNVER4) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_IS_ZNVER4		|| __builtin_cpu_is("znver4")
+#else
+#define TARGET_CLONE_IS_ZNVER4
+#endif
+
+#if defined(HAVE_TARGET_CLONES_ZNVER5) &&		\
+    defined(HAVE_COMPILER_GCC_OR_MUSL)
+#define TARGET_CLONE_IS_ZNVER5		|| __builtin_cpu_is("znver5")
+#else
+#define TARGET_CLONE_IS_ZNVER5
+#endif
+
+#if defined(TARGET_CLONE_AVX512_BY_FEATURE) &&	\
+    defined(HAVE_TARGET_CLONES_SKYLAKE_AVX512)
+#define TARGET_CLONE_AVX512F	"avx512f",
+#define TARGET_CLONE_USE
+#else
+#define TARGET_CLONE_AVX512F
+#endif
+
 #define TARGET_CLONES_ALL		\
 	TARGET_CLONE_AVX		\
 	TARGET_CLONE_AVX2 		\
+	TARGET_CLONE_AVX512F		\
 	TARGET_CLONE_MMX 		\
 	TARGET_CLONE_SSE		\
 	TARGET_CLONE_SSE2 		\

--- a/test/test-ld-wrap-cpu-indicator-init.c
+++ b/test/test-ld-wrap-cpu-indicator-init.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Colin Ian King
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ */
+
+/*
+ *  Probe for a linker that supports --wrap and a libgcc that provides
+ *  __cpu_indicator_init, the initialiser the resolvers emitted for
+ *  target_clones call before reading __cpu_model.
+ */
+#if defined(__x86_64__) ||	\
+    defined(__x86_64) ||	\
+    defined(__amd64__) ||	\
+    defined(__amd64)
+#else
+#error arch not supported
+#endif
+
+struct cpu_model_t {
+	unsigned int __cpu_vendor;
+	unsigned int __cpu_type;
+	unsigned int __cpu_subtype;
+	unsigned int __cpu_features[1];
+};
+
+extern struct cpu_model_t __cpu_model;
+extern void __real___cpu_indicator_init(void);
+
+void __wrap___cpu_indicator_init(void);
+
+void __wrap___cpu_indicator_init(void)
+{
+	__real___cpu_indicator_init();
+}
+
+int main(void)
+{
+	__wrap___cpu_indicator_init();
+
+	return (int)__cpu_model.__cpu_subtype;
+}


### PR DESCRIPTION
Found this while testing on some Github runners (which run under a hypervisor) - it also seems to be similar to https://github.com/ColinIanKing/stress-ng/pull/648#issuecomment-5107805300

`stress-ng` has AVX-512 code that randomly bombs on some Github Runners, with a stack like the following:

```
2026-07-31T20:21:11.4873546Z       Normal  Scheduled  61s   default-scheduler  Successfully assigned default/edera-qosguaranteed-request-s8qct to protect-e2e-k8s-worker2
2026-07-31T20:21:11.4876100Z       Normal  Pulled     58s   kubelet            spec.containers{stress}: Container image "ghcr.io/colinianking/stress-ng@sha256:fb52cee3eb3067cd04f69238f5d9b90edbbda4e8fa310d4fb32452afbd69d716" already present on machine and can be accessed by the pod
2026-07-31T20:21:11.4878141Z       Normal  Created    58s   kubelet            spec.containers{stress}: Container created
2026-07-31T20:21:11.4879209Z       Normal  Started    58s   kubelet            spec.containers{stress}: Container started
2026-07-31T20:21:11.4880035Z
2026-07-31T20:21:11.4880619Z     === logs for pod edera-qosguaranteed-request-s8qct ===
2026-07-31T20:21:11.4881437Z     stress-ng: info:  [1] setting to a 30 secs run per stressor
2026-07-31T20:21:11.4882228Z     stress-ng: info:  [1] dispatching hogs: 1 cpu, 1 vm
2026-07-31T20:21:11.4883219Z     stress-ng: info:  [1] note: system has only 279 MB of free memory and swap, recommend using --oom-avoid
2026-07-31T20:21:11.4884715Z     stress-ng: info:  [3] vm: using 64MB per stressor instance (total 64MB of 279.47MB available memory)
2026-07-31T20:21:11.4885805Z     stress-ng: debug: [2] caught SIGILL, address 0x00000000005e24d5 (ILL_ILLOPN)
2026-07-31T20:21:11.4887203Z     stress-ng: debug: [2] stress-ng: info: 0x00000000005e24d0: ff c5 c1 57 ff<62>f1 47 08 7b e3 62 f1 47 08 7b
2026-07-31T20:21:11.4888421Z     stress-ng: debug: [2] stress-ng: info: 0x00000000005e24e0: c0 c5 db 59 25 df 87 bb 00 c5 f9 13 04 24 c5 fb
2026-07-31T20:21:11.4889612Z     stress-ng: debug: [2] stress-ng: info: 0x00000000005e24f0: 11 64 24 10 e8 37 5b e9 ff bb e8 03 00 00 c5 e9
2026-07-31T20:21:11.4890777Z     stress-ng: debug: [2] stress-ng: info: 00404000-0112a000 r-xp 00004000 00:1e 381 /usr/bin/stress-ng
2026-07-31T20:21:11.4891876Z     stress-ng: error: [1] cpu: [2] terminated with an error, exit status=2 (stressor failed)
2026-07-31T20:21:11.4892863Z     stress-ng: debug: [4] caught SIGILL, address 0x0000000000e5d62c (ILL_ILLOPN)
2026-07-31T20:21:11.4893921Z     stress-ng: debug: [4] stress-ng: info: 0x0000000000e5d620: c5 f8 77 e8 e8 ae 61 ff 49 83 c5 40<62>f2 7d 48
2026-07-31T20:21:11.4895493Z     stress-ng: debug: [4] stress-ng: info: 0x0000000000e5d630: 7a c0 62 d1 7f 48 7f 45 ff 49 8b 47 10 49 39 c5
2026-07-31T20:21:11.4896781Z     stress-ng: debug: [4] stress-ng: info: 0x0000000000e5d640: 72 de 49 8b 7f 08 48 39 c7 0f 83 db 02 00 00 48
2026-07-31T20:21:11.4897939Z     stress-ng: debug: [4] stress-ng: info: 00404000-0112a000 r-xp 00004000 00:1e 381 /usr/bin/stress-ng
2026-07-31T20:21:11.4899027Z     stress-ng: error: [1] vm: [3] terminated with an error, exit status=2 (stressor failed)
```

[Github runners run under the Hyper-V hypervisor on Azure and do not seem to consistently have AVX-512 support](https://github.com/actions/runner-images/issues/3389), and the only way this seems possible is because `stress-ng` is using CPU model detection, not feature detection, so if the _model_ supports AVX-512, but the _feature_ is masked or otherwise disabled on the CPU or via the hypervisor, `stress-ng` will try to use the AVX-512 routines and be SIGILL'd because of an invalid operation.

It is reproducible locally with `stress-ng` under `qemu`, by passing a CPU that *normally* supports AVX-512, but with that specific feature being disabled/masked by the hypervisor:

` qemu-x86_64 -cpu Skylake-Server,-avx512f,-avx512dq,-avx512bw,-avx512vl,-avx512cd \
      /usr/bin/stress-ng --cpu 1 --timeout 5s`


This patch fixes cases where AVX-512 is not advertised as supported for a CPU, even though the model *should* have it (it will still fail if AVX-512 is advertised as supported, but isn't implemented, fixing _that_ is out of scope here).
  
This patch ensures a match on the CPU model cannot select AVX-512 that the CPU hasn't been verified to support, by clearing the model classification when it claims AVX-512 that `__builtin_cpu_supports()` reports as unusable. This forces detection to be feature-based instead.

This only fires when the model and the actual AVX-512 feature support are detected to disagree, this is a signal we can't trust blanket statements about AVX-512 support based only on the model, and have to probe the feature specifically.

Fixes the issue with qemu above and the issue I've seen on runners.
