### PR TITLE
stress-sem-sysv: --verify "corrupted bogo-ops counter" from concurrent counter updates in forked children

### DIFF
--- a/stress-sem-sysv.c
+++ b/stress-sem-sysv.c
@@ -61,6 +61,16 @@ static const stress_opt_t opts[] = {
 #if defined(HAVE_SEM_SYSV) &&	\
     defined(HAVE_KEY_T)
 /*
+ *  Shared bogo-ops counter lock. sem-sysv forks multiple child processes
+ *  that all share and update the same bogo-ops counter. A bare
+ *  stress_bogo_inc() is a non-atomic read-modify-write, so concurrent
+ *  children race and lose updates, which trips the --verify metrics
+ *  check (e.g. "corrupted bogo-ops counter, 751 vs 750"). Serialise the
+ *  updates with a shared lock via stress_bogo_inc_lock() instead.
+ */
+static void *sem_sysv_counter_lock;
+
+/*
  *  stress_semaphore_sysv_init()
  *	initialise a System V semaphore
  */
@@ -257,7 +267,8 @@ static int OPTIMIZE3 stress_semaphore_sysv_thrash(
 				break;
 			}
 timed_out:
-			stress_bogo_inc(args);
+			if (UNLIKELY(!stress_bogo_inc_lock(args, sem_sysv_counter_lock, true)))
+				break;
 			if (UNLIKELY(!stress_continue(args)))
 				break;
 		}
@@ -588,6 +599,18 @@ static int stress_sem_sysv(stress_args_t *args)
 		return EXIT_NO_RESOURCE;
 	}
 
+	/*
+	 *  Create the shared bogo-ops counter lock before forking so all
+	 *  child processes inherit it and serialise counter updates.
+	 */
+	sem_sysv_counter_lock = stress_lock_create("counter");
+	if (!sem_sysv_counter_lock) {
+		pr_inf_skip("%s: failed to create counter lock, skipping stressor\n",
+			args->name);
+		stress_sync_s_pids_munmap(s_pids, MAX_SEM_SYSV_PROCS);
+		return EXIT_NO_RESOURCE;
+	}
+
 	for (i = 0; i < semaphore_sysv_procs; i++) {
 		stress_sync_start_init(&s_pids[i]);
 
@@ -608,6 +631,8 @@ static int stress_sem_sysv(stress_args_t *args)
 reap:
 	stress_proc_state_set(args->name, STRESS_STATE_DEINIT);
 	stress_kill_and_wait_many(args, s_pids, semaphore_sysv_procs, SIGALRM, true);
+	if (sem_sysv_counter_lock)
+		(void)stress_lock_destroy(sem_sysv_counter_lock);
 	stress_sync_s_pids_munmap(s_pids, MAX_SEM_SYSV_PROCS);
 
 	return rc;


### PR DESCRIPTION
Version:  seen on 0.20.00, and the same code path is still present on git
          master 0.21.04 (commit 822f23d), stress-sem-sysv.c,
          stress_semaphore_sysv_thrash().
Arch/OS:  x86_64.
          Reproduced on:
            - Ubuntu, kernel 4.15.0-aws-fips, gcc 9.4/7.5, glibc 2.31/2.27
              (Intel), with the default loop below.
            - Ubuntu, kernel 7.0.0-generic, gcc 15.2, glibc 2.43
              (AMD EPYC-Rome, 2 vCPU), using short runs (see Reproduction).

What I'm seeing
---------------
When running sem-sysv under --verify, I occasionally get a metrics failure:

    stress-ng: fail:  [21453] sem-sysv instance 3 corrupted bogo-ops counter, 751 vs 750
    stress-ng: fail:  [21453] sem-sysv instance 3 hash error in bogo-ops counter and run flag, 2210998880 vs 47247250
    stress-ng: fail:  [21453] metrics-check: stressor metrics corrupted, data is compromised

Nothing crashes; all children exit successfully. The counter is just off,
usually by one.

What I think is going on
------------------------
The sem-sysv stressor forks several child processes (sem-sysv-procs, default
2, up to 64) that all run stress_semaphore_sysv_thrash() and each call
stress_bogo_inc(args) at the "timed_out:" label.

As far as I can tell, the per-stressor stats block holding the bogo-ops
counter (args->bogo.count.counter) lives in g_shared, which is allocated with
stress_mmap_anon_shared() (MAP_SHARED | MAP_ANON) in stress-ng.c, so it is
shared across fork(). stress_bogo_inc() is a non-atomic read-modify-write:

```
    args->bogo.ci.counter_ready = false;
    stress_asm_mb();
    args->bogo.ci.counter++;          /* not atomic / not locked */
    stress_asm_mb();
    args->bogo.ci.counter_ready = true;
```

So if two children increment at the same time, an update can be lost, which
would explain the off-by-one that --verify catches.

I also noticed the doc comment on stress_bogo_inc()/stress_bogo_add() in
stress-ng.h suggests only incrementing inside a stressor and not in a child
process, which seems related here.

I could of course be misreading the sharing/locking model -- please correct me
if so.

Reproduction
------------
It's timing sensitive. On the 4.15 host the default loop is enough:
```

    for i in $(seq 1 40); do
        ./stress-ng -t 5 --sem-sysv 4 --sem-sysv-ops 3000 --verify || break
    done
```

On faster kernels (7.0) the long default run is too stable to trip; short
runs with staggered child termination expose it reliably:

```
    for i in $(seq 1 300); do
        ./stress-ng -t 1 --sem-sysv 4 --sem-sysv-procs 16 --sem-sysv-ops 500 --verify \
            || break
    done
```

On the 7.0/EPYC host this reproduced within a few hundred iterations, e.g.:

    sem-sysv instance 1 corrupted bogo-ops counter, 131 vs 130
    sem-sysv instance 1 hash error in bogo-ops counter and run flag, 3850945556 vs 3905622311
    metrics-check: stressor metrics corrupted, data is compromised

Raising --sem-sysv-procs and lowering the per-run time/ops both help.

Possible fix
------------
One option that worked for me is to use the existing locked counter helper
(the same pattern stress-rmap.c already uses): create a "counter" lock before
forking so the children inherit it, and use stress_bogo_inc_lock() instead of
stress_bogo_inc().

This commit:
  - adds a file-scope  static void *sem_sysv_counter_lock;
  - creates it with stress_lock_create("counter") before the fork loop
    (and skips the stressor if the lock can't be created);
  - uses stress_bogo_inc_lock(args, sem_sysv_counter_lock, true) at the
    "timed_out:" label instead of stress_bogo_inc(args);
  - destroys it with stress_lock_destroy() in the reap path.

Testing performed
-------------
With the patch on git master (0.21.04, commit 822f23d):
  - builds cleanly on both hosts;
  - on the 4.15-aws-fips host I no longer saw the failure across 30+ verify
    iterations that had been failing before;
  - on the 7.0/EPYC host, the short-run loop that reproduced the failure on
    unpatched master (2/300, and again 1/12) showed 0 failures across 600
    iterations after the patch;
  - normal runs still pass with intact metrics on both hosts; no regression.

Note
----
For what it's worth, the pthread stressor had a similar shared-object pattern
(one &pargs shared across worker threads) that already looks fixed on master
via the per-thread pthread_args[MAX_PTHREAD] array; sem-sysv may just have not
had the equivalent change for its shared counter on commit
b5c04fe4d1dd89230e2f2094ee462bcea80bb067